### PR TITLE
improve symlinked install of targets to support different destination types

### DIFF
--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
@@ -192,26 +192,18 @@ endfunction()
 # :param TARGET_FILES: the absolute files, replacing the name of targets passed
 #   in as TARGETS
 # :type TARGET_FILES: list of files
-# :param ARGN: the same arguments as the CMake install command.
+# :param ARGN: the same arguments as the CMake install command except that
+#   keywords identifying the kind of type and the DESTINATION keyword must be
+#   joined with an underscore, e.g. ARCHIVE_DESTINATION.
 # :type ARGN: various
 #
 function(ament_cmake_symlink_install_targets)
   #message(" - ament_cmake_symlink_install_targets(${ARGN})")
-  cmake_parse_arguments(ARG "ARCHIVE;LIBRARY;RUNTIME;OPTIONAL" "DESTINATION"
+  cmake_parse_arguments(ARG "OPTIONAL" "ARCHIVE_DESTINATION;DESTINATION;LIBRARY_DESTINATION;RUNTIME_DESTINATION"
     "TARGETS;TARGET_FILES" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_cmake_symlink_install_targets() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
-  endif()
-
-  # make destination an absolute path and ensure that it exists
-  if(NOT IS_ABSOLUTE "${ARG_DESTINATION}")
-    set(ARG_DESTINATION "@CMAKE_INSTALL_PREFIX@/${ARG_DESTINATION}")
-  endif()
-  if(NOT EXISTS "${ARG_DESTINATION}")
-    #message(" - ament_cmake_symlink_install_targets() create destination "
-    #  "directory '${ARG_DESTINATION}'")
-    file(MAKE_DIRECTORY "${ARG_DESTINATION}")
   endif()
 
   # iterate over target files
@@ -221,10 +213,34 @@ function(ament_cmake_symlink_install_targets)
         "'${file}' must be an absolute path")
     endif()
 
+    # determine destination of file based on extension
+    set(destination "")
+    get_filename_component(fileext "${file}" EXT)
+    if("${fileext}" STREQUAL ".a" OR "${fileext}" STREQUAL ".lib")
+      set(destination "${ARG_ARCHIVE_DESTINATION}")
+    elseif("${fileext}" STREQUAL ".dylib" OR "${fileext}" STREQUAL ".so")
+      set(destination "${ARG_LIBRARY_DESTINATION}")
+    elseif("${fileext} " STREQUAL " " OR "${fileext}" STREQUAL ".dll" OR "${fileext}" STREQUAL ".exe")
+      set(destination "${ARG_RUNTIME_DESTINATION}")
+    endif()
+    if("${destination} " STREQUAL " ")
+      set(destination "${ARG_DESTINATION}")
+    endif()
+
+    # make destination an absolute path and ensure that it exists
+    if(NOT IS_ABSOLUTE "${destination}")
+      set(destination "@CMAKE_INSTALL_PREFIX@/${destination}")
+    endif()
+    if(NOT EXISTS "${destination}")
+      #message(" - ament_cmake_symlink_install_targets() create destination "
+      #  "directory '${destination}'")
+      file(MAKE_DIRECTORY "${destination}")
+    endif()
+
     if(EXISTS "${file}")
       # determine link name for file including destination path
       get_filename_component(filename "${file}" NAME)
-      set(symlink "${ARG_DESTINATION}/${filename}")
+      set(symlink "${destination}/${filename}")
       #message(" - ament_cmake_symlink_install_targets() create symlink "
       #  "'${symlink}' pointing to '${file}'")
       _ament_cmake_symlink_create_symlink("${file}" "${symlink}")

--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
@@ -66,6 +66,13 @@ function(ament_cmake_symlink_install_targets)
     string(REPLACE ";" "\" \"" target_files_quoted
       "\"TARGET_FILES;${target_files}\"")
     string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
+
+    # join destination keyword with kind of target (e.g. ARCHIVE)
+    # to simplify parsing in the next CMake function
+    string(REPLACE "\"ARCHIVE\" \"DESTINATION\"" "\"ARCHIVE_DESTINATION\"" argn_quoted "${argn_quoted}")
+    string(REPLACE "\"LIBRARY\" \"DESTINATION\"" "\"LIBRARY_DESTINATION\"" argn_quoted "${argn_quoted}")
+    string(REPLACE "\"RUNTIME\" \"DESTINATION\"" "\"RUNTIME_DESTINATION\"" argn_quoted "${argn_quoted}")
+
     ament_cmake_symlink_install_append_install_code(
       "ament_cmake_symlink_install_targets(${target_files_quoted};${argn_quoted})"
       COMMENTS "install(${argn_quoted})"


### PR DESCRIPTION
Connects to #4. I listed all extensions I could think of for now without running it on Windows.

@wjwwood Please check if it installs all targets in the correct locations on Windows.