### PR TITLE
Fixing some CMake warnings

### DIFF
--- a/ament_cmake_core/cmake/core/all.cmake
+++ b/ament_cmake_core/cmake/core/all.cmake
@@ -65,6 +65,10 @@ if(NOT PROJECT_NAME)
   project(ament_cmake_internal NONE)
 endif()
 
+# use AMENT_ENABLE_TESTING to avoid warnings about not using it
+if(DEFINED AMENT_ENABLE_TESTING AND AMENT_ENABLE_TESTING)
+endif()
+
 # include CMake functions
 include(CMakeParseArguments)
 

--- a/ament_cmake_core/cmake/core/all.cmake
+++ b/ament_cmake_core/cmake/core/all.cmake
@@ -53,6 +53,12 @@ _set_cmake_policy_to_new_if_available(CMP0020)
 _set_cmake_policy_to_new_if_available(CMP0021)
 _set_cmake_policy_to_new_if_available(CMP0022)
 _set_cmake_policy_to_new_if_available(CMP0023)
+_set_cmake_policy_to_new_if_available(CMP0042)
+
+# set RPATH to ON for OS X
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH ON)
+endif()
 
 # the following operations must be performed inside a project context
 if(NOT PROJECT_NAME)


### PR DESCRIPTION
This fixes two common CMake warnings:

- Warning about unused CMake variable `AMENT_ENABLE_TESTING`.
- On OS X warning about RPATH's being set.

Connects to ros2/ros2#53