### PR TITLE
generate per project parent_prefix_path files

### DIFF
--- a/ament_cmake_core/cmake/environment/ament_cmake_environment_package_hook.cmake
+++ b/ament_cmake_core/cmake/environment/ament_cmake_environment_package_hook.cmake
@@ -30,17 +30,7 @@ function(ament_cmake_environment_generate_package_run_dependencies_marker)
 endfunction()
 
 function(ament_cmake_environment_generate_parent_prefix_path_marker)
-  if(NOT "$ENV{AMENT_PREFIX_PATH} " STREQUAL " ")
-    set(marker_file
-      "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment/parent_prefix_path")
-    file(WRITE "${marker_file}" "$ENV{AMENT_PREFIX_PATH}")
-    file(MD5 "${marker_file}" md5)
-    install(
-      FILES "${marker_file}"
-      DESTINATION "share/ament_parent_prefix_path"
-      RENAME "${md5}"
-    )
-  endif()
+  ament_index_register_resource("parent_prefix_path" CONTENT "$ENV{AMENT_PREFIX_PATH}")
 endfunction()
 
 if(AMENT_CMAKE_ENVIRONMENT_PARENT_PREFIX_PATH_GENERATION)


### PR DESCRIPTION
This gets rid of the last overlapping file between packages.