### PR TITLE
improve test runner

### DIFF
--- a/ament_cmake_gtest/cmake/ament_add_gtest.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest.cmake
@@ -78,6 +78,7 @@ function(_ament_add_gtest target)
   ament_add_test(
     "${target}"
     COMMAND ${cmd}
+    OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_gtest/${target}.txt"
     ${ARG_TIMEOUT}
     ${ARG_WORKING_DIRECTORY}
   )

--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -60,6 +60,7 @@ function(_ament_add_nose_test testname path)
   ament_add_test(
     "${testname}"
     COMMAND ${cmd}
+    OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_nose/${target}.txt"
     ${ARG_TIMEOUT}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   )

--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -63,7 +63,7 @@ function(ament_add_test testname)
   endif()
 
   # wrap command with run_test script to ensure test result generation
-  set(cmd_wrapper "${PYTHON_EXECUTABLE}" "${ament_cmake_test_DIR}/run_test.py"
+  set(cmd_wrapper "${PYTHON_EXECUTABLE}" "-u" "${ament_cmake_test_DIR}/run_test.py"
     "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${testname}.xml")
   if(ARG_GENERATE_RESULT_FOR_RETURN_CODE_ZERO)
     list(APPEND cmd_wrapper "--generate-result-on-success")

--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -86,6 +86,9 @@ def main(argv=sys.argv[1:]):
     output = ''
     h = None
     if args.output_file:
+        output_path = os.path.dirname(args.output_file)
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
         h = open(args.output_file, 'wb')
     try:
         proc = subprocess.Popen(args.command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -95,6 +98,7 @@ def main(argv=sys.argv[1:]):
             output += decoded_line
             if h:
                 h.write(line)
+                h.flush()
         proc.wait()
         rc = proc.returncode
         print('-- run_test.py: return code', rc, file=sys.stderr if rc else sys.stdout)


### PR DESCRIPTION
This patch improves the test runner by:

* using unbuffered output for the `run_test.py` script
* update gtests and nosetests to also dump the output into a file
* flush the output file after every line to ensure it contains all information

This is necessary e.g. in the case that a test gets killed by a timeout. Two of these tests (http://ci.ros2.org/job/ros2_batch_ci_linux/135/console#console-section-0) printed nothing when they timed out.