### PR TITLE
load CONFIG_EXTRAS before exported information

### DIFF
--- a/ament_cmake_core/cmake/core/ament_package.cmake
+++ b/ament_cmake_core/cmake/core/ament_package.cmake
@@ -72,7 +72,7 @@ function(_ament_package)
 
   # expand and install config extras
   set(PACKAGE_CONFIG_EXTRA_FILES "")
-  foreach(extra ${${PROJECT_NAME}_CONFIG_EXTRAS} ${PACKAGE_CONFIG_EXTRAS})
+  foreach(extra ${PACKAGE_CONFIG_EXTRAS} ${${PROJECT_NAME}_CONFIG_EXTRAS})
     assert_file_exists("${extra}"
       "ament_package() called with extra file '${extra}' which does not exist")
     stamp("${extra}")


### PR DESCRIPTION
This allows to e.g. extend the `CMAKE_MODULE_PATH` to make exporting `Foo` work using a custom module.