### PR TITLE
set cmp0026 to OLD until we can migrate to use $<TARGET_FILE:...>

### DIFF
--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
@@ -71,7 +71,7 @@ function(ament_cmake_symlink_install_targets)
       endif()
       # TODO consider using a generator expression instead
       # $<TARGET_FILE:target>
-      # Until them use the old policy.
+      # until then set the policy explicitly in order to avoid warning with newer CMake versions.
       if(POLICY CMP0026)
         cmake_policy(SET CMP0026 OLD)
       endif()

--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
@@ -71,6 +71,10 @@ function(ament_cmake_symlink_install_targets)
       endif()
       # TODO consider using a generator expression instead
       # $<TARGET_FILE:target>
+      # Until them use the old policy.
+      if(POLICY CMP0026)
+        cmake_policy(SET CMP0026 OLD)
+      endif()
       get_property(location TARGET ${target} PROPERTY LOCATION)
       list(APPEND target_files "${location}")
     endforeach()

--- a/ament_cmake_gmock/cmake/ament_add_gmock.cmake
+++ b/ament_cmake_gmock/cmake/ament_add_gmock.cmake
@@ -59,6 +59,12 @@ function(_ament_add_gmock target)
     target_link_libraries("${target}" ${GMOCK_MAIN_LIBRARIES})
   endif()
 
+  # TODO consider using a generator expression instead
+  # $<TARGET_FILE:target>
+  # until then set the policy explicitly in order to avoid warning with newer CMake versions.
+  if(POLICY CMP0026)
+    cmake_policy(SET CMP0026 OLD)
+  endif()
   get_target_property(executable "${target}" LOCATION)
   string(REPLACE "$(Configuration)" "$<CONFIGURATION>" executable "${executable}")
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${target}.gtest.xml")

--- a/ament_cmake_gtest/cmake/ament_add_gtest.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest.cmake
@@ -62,6 +62,12 @@ function(_ament_add_gtest target)
     target_link_libraries("${target}" ${GTEST_MAIN_LIBRARIES})
   endif()
 
+  # TODO consider using a generator expression instead
+  # $<TARGET_FILE:target>
+  # until then set the policy explicitly in order to avoid warning with newer CMake versions.
+  if(POLICY CMP0026)
+    cmake_policy(SET CMP0026 OLD)
+  endif()
   get_target_property(executable "${target}" LOCATION)
   string(REPLACE "$(Configuration)" "$<CONFIGURATION>" executable "${executable}")
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${target}.gtest.xml")


### PR DESCRIPTION
This should fix https://github.com/ament/ament_cmake/issues/27.

Connects to #27