### PR TITLE
move '.missing_result' suffix from testsuite name to testcase name

### DIFF
--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -192,18 +192,19 @@ def main(argv=sys.argv[1:]):
 
 
 def _generate_result(result_file, failure_message=None):
+    # the generated result file must be readable
+    # by any of the Jenkins test result report publishers
     pkgname = os.path.basename(os.path.dirname(result_file))
     testname = os.path.splitext(os.path.basename(result_file))[0]
-    name = '%s.%s' % (pkgname, testname)
     failure_message = '<failure message=%s/>' % quoteattr(failure_message) \
         if failure_message else ''
     return '''<?xml version="1.0" encoding="UTF-8"?>
-<testsuite tests="1" failures="%d" time="1" errors="0" name="%s">
-  <testcase name="missing_result" status="run" time="1" classname="%s">
+<testsuite name="%s" tests="1" failures="%d" time="0" errors="0">
+  <testcase classname="%s" name="%s.missing_result" status="run" time="0">
     %s
   </testcase>
 </testsuite>\n''' % \
-        (1 if failure_message else 0, name, name, failure_message)
+        (pkgname, 1 if failure_message else 0, pkgname, testname, failure_message)
 
 
 def _tidy_xml(filename):


### PR DESCRIPTION
By moving the suffix to the `testcase` Jenkins shows better grouping / hierarchy for these tests.

Before:
* http://ci.ros2.org/job/ros2_batch_ci_linux/350/testReport/
* http://ci.ros2.org/job/ros2_batch_ci_linux/350/testReport/(root)/test_ament_cmake_gtest_test_results/

After:
* http://ci.ros2.org/job/ros2_batch_ci_linux/354/testReport/
* http://ci.ros2.org/job/ros2_batch_ci_linux/354/testReport/(root)/test_ament_cmake_gtest_test_results/

Related to ros2/ros2#106