### PR TITLE
determine nosetest version in CMake and use --xunit-testsuite-name when available

### DIFF
--- a/ament_cmake_nose/ament_cmake_nose-extras.cmake
+++ b/ament_cmake_nose/ament_cmake_nose-extras.cmake
@@ -29,7 +29,23 @@ macro(_ament_cmake_nose_find_nosetests)
       "nosetests-${PYTHON_VERSION_MAJOR}"
       "nosetests")
     if(NOSETESTS)
-      message(STATUS "Using Python nosetests: ${NOSETESTS}")
+      set(_cmd "${NOSETESTS}" "--version")
+      execute_process(
+        COMMAND ${_cmd}
+        RESULT_VARIABLE _res
+        OUTPUT_VARIABLE _output
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      if(NOT _res EQUAL 0)
+        string(REPLACE ";" " " _cmd_str "${_cmd}")
+        message(FATAL_ERROR "Failed to invoke nosetest: '${_cmd_str}' returned error code ${_res}")
+      endif()
+      string(REPLACE " version " ";" _output_list "${_output}")
+      list(LENGTH _output_list _length)
+      if(NOT _length EQUAL 2)
+        message(FATAL_ERROR "Failed to extract nosetest version from '${_output}'")
+      endif()
+      list(GET _output_list 1 NOSETESTS_VERSION)
+      message(STATUS "Using Python nosetests: ${NOSETESTS} (${NOSETESTS_VERSION})")
     else()
       if("${PYTHON_VERSION_MAJOR} " STREQUAL "3 ")
         set(_python_nosetests_package "python3-nose")

--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -54,6 +54,10 @@ function(_ament_add_nose_test testname path)
   set(cmd
     "${NOSETESTS}" "${path}" "--with-xunit"
     "--xunit-file=${result_file}")
+  if(NOT "${NOSETESTS_VERSION}" LESS "1.3.5")
+    list(APPEND cmd "--xunit-testsuite-name=${PROJECT_NAME}.nosetests")
+  endif()
+
   if(ARG_TIMEOUT)
     set(ARG_TIMEOUT "TIMEOUT" "${ARG_TIMEOUT}")
   endif()


### PR DESCRIPTION
Same as for Python packages: https://github.com/ament/ament_tools/blob/60c0ac484161c4490ec157206f56055d4fccb3cc/ament_tools/build_types/ament_python.py#L153-L156

Before:

    <?xml version="1.0" encoding="UTF-8"?>
    <testsuite name="nosetests" tests="1" errors="0" failures="0" skip="0">
      <testcase classname="nose_successful_test_result" name="test_successful_test_results" time="0.000"></testcase>
    </testsuite>

After:

    <?xml version="1.0" encoding="UTF-8"?>
    <testsuite name="test_ament_cmake_nose_test_results.nosetests" tests="1" errors="0" failures="0" skip="0">
      <testcase classname="nose_successful_test_result" name="test_successful_test_results" time="0.000"></testcase>
    </testsuite>

Connect to ros2/ros2#106