### PR TITLE
add option to pass extra env to ament_add_*test

### DIFF
--- a/ament_cmake_gmock/cmake/ament_add_gmock.cmake
+++ b/ament_cmake_gmock/cmake/ament_add_gmock.cmake
@@ -44,7 +44,7 @@ macro(ament_add_gmock target)
 endmacro()
 
 function(_ament_add_gmock target)
-  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "TIMEOUT" "" ${ARGN})
+  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "TIMEOUT" "ENV" ${ARGN})
   if(NOT ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR
       "ament_add_gmock() must be invoked with at least one source file")
@@ -71,6 +71,9 @@ function(_ament_add_gmock target)
   set(cmd
     "${executable}"
     "--gtest_output=xml:${result_file}")
+  if(ARG_ENV)
+    set(ARG_ENV "ENV" ${ARG_ENV})
+  endif()
   if(ARG_TIMEOUT)
     set(ARG_TIMEOUT "TIMEOUT" ${ARG_TIMEOUT})
   endif()
@@ -83,6 +86,7 @@ function(_ament_add_gmock target)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_gmock/${target}.txt"
     RESULT_FILE "${result_file}"
+    ${ARG_ENV}
     ${ARG_TIMEOUT}
     ${ARG_WORKING_DIRECTORY}
   )

--- a/ament_cmake_gtest/cmake/ament_add_gtest.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest.cmake
@@ -47,7 +47,7 @@ macro(ament_add_gtest target)
 endmacro()
 
 function(_ament_add_gtest target)
-  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "TIMEOUT;ENV" "" ${ARGN})
+  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "TIMEOUT" "ENV" ${ARGN})
   if(NOT ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR
       "ament_add_gtest() must be invoked with at least one source file")
@@ -74,6 +74,9 @@ function(_ament_add_gtest target)
   set(cmd
     "${executable}"
     "--gtest_output=xml:${result_file}")
+  if(ARG_ENV)
+    set(ARG_ENV "ENV" ${ARG_ENV})
+  endif()
   if(ARG_TIMEOUT)
     set(ARG_TIMEOUT "TIMEOUT" ${ARG_TIMEOUT})
   endif()
@@ -86,7 +89,7 @@ function(_ament_add_gtest target)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_gtest/${target}.txt"
     RESULT_FILE "${result_file}"
-    ENV ${ARG_ENV}
+    ${ARG_ENV}
     ${ARG_TIMEOUT}
     ${ARG_WORKING_DIRECTORY}
   )

--- a/ament_cmake_gtest/cmake/ament_add_gtest.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest.cmake
@@ -47,7 +47,7 @@ macro(ament_add_gtest target)
 endmacro()
 
 function(_ament_add_gtest target)
-  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "TIMEOUT" "" ${ARGN})
+  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "TIMEOUT;ENV" "" ${ARGN})
   if(NOT ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR
       "ament_add_gtest() must be invoked with at least one source file")
@@ -86,6 +86,7 @@ function(_ament_add_gtest target)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_gtest/${target}.txt"
     RESULT_FILE "${result_file}"
+    ENV ${ARG_ENV}
     ${ARG_TIMEOUT}
     ${ARG_WORKING_DIRECTORY}
   )

--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -42,7 +42,7 @@ include(CMakeParseArguments)
 #
 function(ament_add_test testname)
   cmake_parse_arguments(ARG "GENERATE_RESULT_FOR_RETURN_CODE_ZERO"
-    "ENV;OUTPUT_FILE;RESULT_FILE;TIMEOUT;WORKING_DIRECTORY" "COMMAND" ${ARGN})
+    "OUTPUT_FILE;RESULT_FILE;TIMEOUT;WORKING_DIRECTORY" "COMMAND;ENV" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_add_test() called with unused arguments: "
       "${ARG_UNPARSED_ARGUMENTS}")
@@ -75,7 +75,10 @@ function(ament_add_test testname)
     list(APPEND cmd_wrapper "--output-file" "${ARG_OUTPUT_FILE}")
   endif()
   if(ARG_ENV)
-    list(APPEND cmd_wrapper "--env" "${ARG_ENV}")
+    list(APPEND cmd_wrapper "--env")
+    foreach(_env ${ARG_ENV})
+      list(APPEND cmd_wrapper "${_env}")
+    endforeach()
   endif()
   list(APPEND cmd_wrapper "--command" ${ARG_COMMAND})
 

--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -42,7 +42,7 @@ include(CMakeParseArguments)
 #
 function(ament_add_test testname)
   cmake_parse_arguments(ARG "GENERATE_RESULT_FOR_RETURN_CODE_ZERO"
-    "OUTPUT_FILE;RESULT_FILE;TIMEOUT;WORKING_DIRECTORY" "COMMAND" ${ARGN})
+    "ENV;OUTPUT_FILE;RESULT_FILE;TIMEOUT;WORKING_DIRECTORY" "COMMAND" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_add_test() called with unused arguments: "
       "${ARG_UNPARSED_ARGUMENTS}")
@@ -73,6 +73,9 @@ function(ament_add_test testname)
   endif()
   if(ARG_OUTPUT_FILE)
     list(APPEND cmd_wrapper "--output-file" "${ARG_OUTPUT_FILE}")
+  endif()
+  if(ARG_ENV)
+    list(APPEND cmd_wrapper "--env" "${ARG_ENV}")
   endif()
   list(APPEND cmd_wrapper "--command" ${ARG_COMMAND})
 

--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -43,7 +43,8 @@ def main(argv=sys.argv[1:]):
              'following options.')
     parser.add_argument(
         '--env',
-        help='extra environment to set when running, in the format FOO=foo;BAR=bar')
+        nargs='+',
+        help='extra environment variables to set when running, e.g. FOO=foo BAR=bar')
     parser.add_argument(
         '--output-file',
         help='The path to the output log file')
@@ -100,8 +101,7 @@ def main(argv=sys.argv[1:]):
     extra_env = dict(os.environ)
     if args.env:
         log("-- run_test.py: extra environment variables:")
-        envs = args.env.split(';')
-        for env in envs:
+        for env in args.env:
             split_env = env.split('=')
             assert(len(split_env) >= 2)
             key = split_env[0]

--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -44,7 +44,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--env',
         nargs='+',
-        help='extra environment variables to set when running, e.g. FOO=foo BAR=bar')
+        help='Extra environment variables to set when running, e.g. FOO=foo BAR=bar')
     parser.add_argument(
         '--output-file',
         help='The path to the output log file')
@@ -98,16 +98,19 @@ def main(argv=sys.argv[1:]):
             output_handle.write((msg + '\n').encode())
             output_handle.flush()
 
-    extra_env = dict(os.environ)
+    env = None
     if args.env:
-        log("-- run_test.py: extra environment variables:")
-        for env in args.env:
-            split_env = env.split('=')
-            assert(len(split_env) >= 2)
-            key = split_env[0]
-            value = '='.join(split_env[1:])
-            log(" - {0}={1}".format(key, value))
-            extra_env[key] = value
+        env = dict(os.environ)
+        log('-- run_test.py: extra environment variables:')
+        for env_str in args.env:
+            try:
+                index = env_str.index('=')
+            except ValueError:
+                parser.error("--env argument '%s' contains no equal sign", env_str)
+            key = env_str[0:index]
+            value = env_str[index + 1:]
+            log(' - {0}={1}'.format(key, value))
+            env[key] = value
 
     log("-- run_test.py: invoking following command in '%s':\n - %s" %
         (os.getcwd(), ' '.join(args.command)))
@@ -118,7 +121,7 @@ def main(argv=sys.argv[1:]):
     try:
         proc = subprocess.Popen(
             args.command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            env=extra_env
+            env=env
         )
         while True:
             line = proc.stdout.readline()


### PR DESCRIPTION
I needed this to pass some environment to tests on OS X. I think the changes are pretty self explanatory.

One nice thing is that you can pass generator expressions through this variable and it works, e.g. I have the cmake code:

```
ament_add_gtest(test_allocator
    test/rcl/test_allocator.cpp
    ENV DYLD_INSERT_LIBRARIES=$<TARGET_FILE:${PROJECT_NAME}_memory_tools_interpose>)
```

Which results in these args to `run_test.py`:

```
3: Test command: /usr/local/bin/python3 "-u" "/Users/william/ros2/install/share/ament_cmake_test/cmake/run_test.py" "/Users/william/ros2/build/rcl/test_results/rcl/test_time.gtest.xml" "--output-file" "/Users/william/ros2/build/rcl/ament_cmake_gtest/test_time.txt" "--env" "DYLD_INSERT_LIBRARIES=/Users/william/ros2/build/rcl/librcl_memory_tools_interpose.dylib" "--command" "/Users/william/ros2/build/rcl/test_time" "--gtest_output=xml:/Users/william/ros2/build/rcl/test_results/rcl/test_time.gtest.xml"
3: Test timeout computed to be: 60
3: -- run_test.py: extra environment variables:
3:  - DYLD_INSERT_LIBRARIES=/Users/william/ros2/build/rcl/librcl_memory_tools_interpose.dylib
3: -- run_test.py: invoking following command in '/Users/william/ros2/build/rcl':
3:  - /Users/william/ros2/build/rcl/test_time --gtest_output=xml:/Users/william/ros2/build/rcl/test_results/rcl/test_time.gtest.xml
3: Running main() from gtest_main.cc
[ ... ]
```