### PR TITLE
look for the package.xml in the project's source dir

### DIFF
--- a/ament_cmake_core/cmake/core/ament_package_xml.cmake
+++ b/ament_cmake_core/cmake/core/ament_package_xml.cmake
@@ -66,7 +66,7 @@ macro(_ament_package_xml dest_dir)
 
   # set default directory
   if(NOT PACKAGE_XML_DIRECTORY)
-    set(PACKAGE_XML_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set(PACKAGE_XML_DIRECTORY ${PROJECT_SOURCE_DIR})
   endif()
 
   # stamp package.xml as well as script to generate CMake code from it


### PR DESCRIPTION
This should always be the right directory for finding the current `package.xml`, see:

From https://cmake.org/cmake/help/v3.0/variable/PROJECT_SOURCE_DIR.html:
```
This is the source directory of the most recent project() command.
```