### PR TITLE
Use find_host_package when crosscompiling

### DIFF
--- a/ament_cmake_core/cmake/core/all.cmake
+++ b/ament_cmake_core/cmake/core/all.cmake
@@ -69,6 +69,19 @@ endif()
 if(DEFINED AMENT_ENABLE_TESTING AND AMENT_ENABLE_TESTING)
 endif()
 
+# Search packages for host system instead of packages for target system
+# in case of cross compilation these macro should be defined by toolchain file
+if(NOT COMMAND find_host_package)
+  macro(find_host_package)
+    find_package(${ARGN})
+  endmacro()
+endif()
+if(NOT COMMAND find_host_program)
+  macro(find_host_program)
+    find_program(${ARGN})
+  endmacro()
+endif()
+
 # include CMake functions
 include(CMakeParseArguments)
 

--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -19,5 +19,5 @@ if(NOT PYTHON_VERSION)
   set(PYTHON_VERSION "3")
 endif()
 
-find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+find_host_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 message(STATUS "Using PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")


### PR DESCRIPTION
Use find_host_package to ensure that we use the host's search path if cross-compiling