### PR TITLE
generate all ament index markers into <build>/ament_index_preinstall

### DIFF
--- a/ament_cmake_core/ament_cmake_index-extras.cmake
+++ b/ament_cmake_core/ament_cmake_index-extras.cmake
@@ -14,6 +14,7 @@
 
 # copied from ament_core/ament_index-extras.cmake
 
+include("${ament_cmake_core_DIR}/index/ament_index_get_prefix_path.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_get_resource.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_get_resources.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_has_resource.cmake")

--- a/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
@@ -17,16 +17,27 @@
 #
 # :param var: the output variable name for the prefix path
 # :type var: string
+# :param SKIP_AMENT_PREFIX_PATH: if set skip adding the paths from the
+#   environment variable ``AMENT_PREFIX_PATH``
+# :type SKIP_AMENT_PREFIX_PATH: option
+# :param SKIP_BINARY_DIR: if set skip adding the folder within the binary dir
+# :type SKIP_BINARY_DIR: option
 #
 # @public
 #
 function(ament_index_get_prefix_path var)
-  if(NOT "${ARGN} " STREQUAL " ")
+  cmake_parse_arguments(ARG
+    "SKIP_AMENT_PREFIX_PATH;SKIP_BINARY_DIR" "" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_index_get_prefix_path() called with unused "
-      "arguments: ${ARGN}")
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  string(REPLACE ":" ";" prefix_path "$ENV{AMENT_PREFIX_PATH}")
+  if(NOT ARG_SKIP_AMENT_PREFIX_PATH)
+    string(REPLACE ":" ";" prefix_path "$ENV{AMENT_PREFIX_PATH}")
+  else()
+    set(prefix_path "")
+  endif()
 
   # Remove CMAKE_INSTALL_PREFIX if it is in the list of paths to search,
   # and add it to the list at the front
@@ -34,8 +45,10 @@ function(ament_index_get_prefix_path var)
   list(REMOVE_ITEM prefix_path "${CMAKE_INSTALL_PREFIX}")
   list(INSERT prefix_path 0 "${CMAKE_INSTALL_PREFIX}")
 
-  # prepend path from binary dir
-  list(INSERT prefix_path 0 "${CMAKE_BINARY_DIR}/ament_cmake_index")
+  if(NOT ARG_SKIP_BINARY_DIR)
+    # prepend path from binary dir
+    list(INSERT prefix_path 0 "${CMAKE_BINARY_DIR}/ament_cmake_index")
+  endif()
 
   set(${var} "${prefix_path}" PARENT_SCOPE)
 endfunction()

--- a/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
@@ -34,7 +34,12 @@ function(ament_index_get_prefix_path var)
   endif()
 
   if(NOT ARG_SKIP_AMENT_PREFIX_PATH)
-    string(REPLACE ":" ";" prefix_path "$ENV{AMENT_PREFIX_PATH}")
+    set(prefix_path $ENV{AMENT_PREFIX_PATH})
+    if(NOT WIN32)
+      # Convert it to a list if not on Windows.
+      # On Windows, it is already separated by ; and is a list in CMake.
+      string(REPLACE ":" ";" prefix_path "${prefix_path}")
+    endif()
   else()
     set(prefix_path "")
   endif()

--- a/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
@@ -1,0 +1,41 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Get the prefix path including the folder from the binary dir.
+#
+# :param var: the output variable name for the prefix path
+# :type var: string
+#
+# @public
+#
+function(ament_index_get_prefix_path var)
+  if(NOT "${ARGN} " STREQUAL " ")
+    message(FATAL_ERROR "ament_index_get_prefix_path() called with unused "
+      "arguments: ${ARGN}")
+  endif()
+
+  string(REPLACE ":" ";" prefix_path "$ENV{AMENT_PREFIX_PATH}")
+
+  # Remove CMAKE_INSTALL_PREFIX if it is in the list of paths to search,
+  # and add it to the list at the front
+  # TODO(dirk-thomas) check if this can be removed or the insert can be done
+  list(REMOVE_ITEM prefix_path "${CMAKE_INSTALL_PREFIX}")
+  list(INSERT prefix_path 0 "${CMAKE_INSTALL_PREFIX}")
+
+  # prepend path from binary dir
+  list(INSERT prefix_path 0 "${CMAKE_BINARY_DIR}/ament_cmake_index")
+
+  set(${var} "${prefix_path}" PARENT_SCOPE)
+endfunction()

--- a/ament_cmake_core/cmake/index/ament_index_get_resource.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_resource.cmake
@@ -40,11 +40,7 @@ function(ament_index_get_resource var resource_type resource_name)
       "arguments: ${ARGN}")
   endif()
 
-  string(REPLACE ":" ";" paths_to_search "$ENV{AMENT_PREFIX_PATH}")
-  # Remove CMAKE_INSTALL_PREFIX if it is in the list of paths to search,
-  # and add it to the list at the front
-  list(REMOVE_ITEM paths_to_search "${CMAKE_INSTALL_PREFIX}")
-  list(INSERT paths_to_search 0 "${CMAKE_INSTALL_PREFIX}")
+  ament_index_get_prefix_path(paths_to_search)
   foreach(path IN LISTS paths_to_search)
     set(filename
       "${path}/share/ament_index/resource_index/${resource_type}/${resource_name}")

--- a/ament_cmake_core/cmake/index/ament_index_get_resource.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_resource.cmake
@@ -22,6 +22,9 @@
 # :type resource_type: string
 # :param resource_name: the name of the resource
 # :type resource_name: string
+# :param PREFIX_PATH: the prefix path to search for (default
+#   ``ament_index_get_prefix_path()``).
+# :type PREFIX_PATH: list of strings
 #
 # @public
 #
@@ -35,13 +38,19 @@ function(ament_index_get_resource var resource_type resource_name)
       "ament_index_get_resource() called without a 'resource_name'")
   endif()
 
-  if(NOT "${ARGN} " STREQUAL " ")
+  cmake_parse_arguments(ARG "" "PREFIX_PATH" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_index_get_resource() called with unused "
-      "arguments: ${ARGN}")
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  ament_index_get_prefix_path(paths_to_search)
-  foreach(path IN LISTS paths_to_search)
+  if(ARG_PREFIX_PATH)
+    set(prefix_path "${ARG_PREFIX_PATH}")
+  else()
+    ament_index_get_prefix_path(prefix_path)
+  endif()
+
+  foreach(path IN LISTS prefix_path)
     set(filename
       "${path}/share/ament_index/resource_index/${resource_type}/${resource_name}")
     if(EXISTS "${filename}")

--- a/ament_cmake_core/cmake/index/ament_index_get_resources.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_resources.cmake
@@ -33,11 +33,7 @@ function(ament_index_get_resources var resource_type)
       "arguments: ${ARGN}")
   endif()
 
-  set(raw_paths_to_search "$ENV{AMENT_PREFIX_PATH}")
-  if(NOT WIN32)
-    # convert the path separator to CMake list separators
-    string(REPLACE ":" ";" raw_paths_to_search "${raw_paths_to_search}")
-  endif()
+  ament_index_get_prefix_path(raw_paths_to_search)
   # Remove any empty strings and make sure slashes are consistent
   set(paths_to_search)
   foreach(path IN LISTS raw_paths_to_search)
@@ -46,10 +42,6 @@ function(ament_index_get_resources var resource_type)
       list_append_unique(paths_to_search "${normalized_path}")
     endif()
   endforeach()
-  # Remove CMAKE_INSTALL_PREFIX if it is in the list of paths to search,
-  # and add it to the list at the front
-  list(REMOVE_ITEM paths_to_search "${CMAKE_INSTALL_PREFIX}")
-  list(INSERT paths_to_search 0 "${CMAKE_INSTALL_PREFIX}")
   set(all_resources "")
   foreach(path IN LISTS paths_to_search)
     file(GLOB resources

--- a/ament_cmake_core/cmake/index/ament_index_get_resources.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_resources.cmake
@@ -19,6 +19,9 @@
 # :type var: list of resource names
 # :param resource_type: the type of the resource
 # :type resource_type: string
+# :param PREFIX_PATH: the prefix path to search for (default
+#   ``ament_index_get_prefix_path()``).
+# :type PREFIX_PATH: list of strings
 #
 # @public
 #
@@ -28,15 +31,21 @@ function(ament_index_get_resources var resource_type)
       "ament_index_get_resources() called without a 'resource_type'")
   endif()
 
-  if(NOT "${ARGN} " STREQUAL " ")
+  cmake_parse_arguments(ARG "" "PREFIX_PATH" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_index_get_resources() called with unused "
-      "arguments: ${ARGN}")
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  ament_index_get_prefix_path(raw_paths_to_search)
+  if(ARG_PREFIX_PATH)
+    set(prefix_path "${ARG_PREFIX_PATH}")
+  else()
+    ament_index_get_prefix_path(prefix_path)
+  endif()
+
   # Remove any empty strings and make sure slashes are consistent
   set(paths_to_search)
-  foreach(path IN LISTS raw_paths_to_search)
+  foreach(path IN LISTS prefix_path)
     if(NOT "${path} " STREQUAL " ")
       string(REPLACE "\\" "/" normalized_path "${path}")
       list_append_unique(paths_to_search "${normalized_path}")

--- a/ament_cmake_core/cmake/index/ament_index_has_resource.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_has_resource.cmake
@@ -21,6 +21,9 @@
 # :type resource_type: string
 # :param resource_name: the name of the resource
 # :type resource_name: string
+# :param PREFIX_PATH: the prefix path to search for (default
+#   ``ament_index_get_prefix_path()``).
+# :type PREFIX_PATH: list of strings
 #
 # @public
 #
@@ -34,14 +37,20 @@ function(ament_index_has_resource var resource_type resource_name)
       "ament_index_has_resource() called without a 'resource_name'")
   endif()
 
-  if(NOT "${ARGN} " STREQUAL " ")
+  cmake_parse_arguments(ARG "" "PREFIX_PATH" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_index_has_resource() called with unused "
-      "arguments: ${ARGN}")
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  ament_index_get_prefix_path(paths_to_search)
+  if(ARG_PREFIX_PATH)
+    set(prefix_path "${ARG_PREFIX_PATH}")
+  else()
+    ament_index_get_prefix_path(prefix_path)
+  endif()
+
   set(retval FALSE)
-  foreach(path IN LISTS paths_to_search)
+  foreach(path IN LISTS prefix_path)
     if(EXISTS
         "${path}/share/ament_index/resource_index/${resource_type}/${resource_name}")
       set(retval TRUE)

--- a/ament_cmake_core/cmake/index/ament_index_has_resource.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_has_resource.cmake
@@ -39,11 +39,7 @@ function(ament_index_has_resource var resource_type resource_name)
       "arguments: ${ARGN}")
   endif()
 
-  string(REPLACE ":" ";" paths_to_search "$ENV{AMENT_PREFIX_PATH}")
-  # Remove CMAKE_INSTALL_PREFIX if it is in the list of paths to search,
-  # and add it to the list at the front
-  list(REMOVE_ITEM paths_to_search "${CMAKE_INSTALL_PREFIX}")
-  list(INSERT paths_to_search 0 "${CMAKE_INSTALL_PREFIX}")
+  ament_index_get_prefix_path(paths_to_search)
   set(retval FALSE)
   foreach(path IN LISTS paths_to_search)
     if(EXISTS

--- a/ament_cmake_core/cmake/index/ament_index_register_package.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_register_package.cmake
@@ -23,9 +23,9 @@ include(CMakeParseArguments)
 #
 function(ament_index_register_package)
   cmake_parse_arguments(ARG "" "PACKAGE_NAME" "" ${ARGN})
-  if(ARGN)
-    message(FATAL_ERROR
-      "ament_index_register_package() called with unused arguments: ${ARGN}")
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_index_register_package() called with unused "
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
   # register package name with the resource type 'packages'

--- a/ament_cmake_core/cmake/index/ament_index_register_resource.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_register_resource.cmake
@@ -73,7 +73,7 @@ function(ament_index_register_resource resource_type)
 
   set(destination "share/ament_index/resource_index/${resource_type}")
   set(marker_file
-    "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_index/${resource_type}/${ARG_PACKAGE_NAME}")
+    "${CMAKE_BINARY_DIR}/ament_cmake_index/${destination}/${ARG_PACKAGE_NAME}")
 
   if(ARG_CONTENT OR NOT ARG_CONTENT_FILE)
     # use the CONTENT argument to create the marker file

--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -88,6 +88,15 @@ function(ament_add_test testname)
   if(ARG_ENV)
     list(APPEND cmd_wrapper "--env")
     foreach(_env ${ARG_ENV})
+      # TODO(wjwwood): remove this when we have a better way to pass PATH lists
+      #   to environment variables on Windows.
+      if(WIN32)
+        # In order to pass a ;-separated list of paths into this function on
+        # Windows, the calling code may have had to replace ;'s to avoid it
+        # them from being interpreted as a CMake list, so undo that
+        # substitution here.
+        string(REPLACE "\;" ";" _env "${_env}")
+      endif()
       list(APPEND cmd_wrapper "${_env}")
     endforeach()
   endif()
@@ -108,6 +117,15 @@ function(ament_add_test testname)
   if(ARG_APPEND_ENV)
     list(APPEND cmd_wrapper "--append-env")
     foreach(_env ${ARG_APPEND_ENV})
+      # TODO(wjwwood): remove this when we have a better way to pass PATH lists
+      #   to environment variables on Windows.
+      if(WIN32)
+        # In order to pass a ;-separated list of paths into this function on
+        # Windows, the calling code may have had to replace ;'s to avoid it
+        # them from being interpreted as a CMake list, so undo that
+        # substitution here.
+        string(REPLACE "\;" ";" _env "${_env}")
+      endif()
       list(APPEND cmd_wrapper "${_env}")
     endforeach()
   endif()

--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -33,7 +33,7 @@ def separate_env_vars(env_str, env_argument_name, parser):
     try:
         index = env_str.index('=')
     except ValueError:
-        parser.error("--%s argument '%s' contains no equal sign", env_argument_name, env_str)
+        parser.error("--%s argument '%s' contains no equal sign" % (env_argument_name, env_str))
     key = env_str[0:index]
     value = env_str[index + 1:]
     return key, value


### PR DESCRIPTION
The benefit to this approach is that the location can be used before install for tests which need the ament_index to be in place.

The "preinstall prefix" is exposed through a new cmake function.

Connects to ros2/rclpy#13