### PR TITLE
use CTest BUILD_TESTING

### DIFF
--- a/ament_cmake_core/cmake/core/all.cmake
+++ b/ament_cmake_core/cmake/core/all.cmake
@@ -65,8 +65,8 @@ if(NOT PROJECT_NAME)
   project(ament_cmake_internal NONE)
 endif()
 
-# use AMENT_ENABLE_TESTING to avoid warnings about not using it
-if(DEFINED AMENT_ENABLE_TESTING AND AMENT_ENABLE_TESTING)
+# use BUILD_TESTING to avoid warnings about not using it
+if(DEFINED BUILD_TESTING AND BUILD_TESTING)
 endif()
 
 # include CMake functions

--- a/ament_cmake_test/ament_cmake_test-extras.cmake
+++ b/ament_cmake_test/ament_cmake_test-extras.cmake
@@ -14,16 +14,15 @@
 
 # copied from ament_cmake_test/ament_cmake_test-extras.cmake
 
-# register environment hook for libraries once
-option(AMENT_ENABLE_TESTING "Enable testing" OFF)
+include(CTest)
+
 # option()
 set(
   AMENT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/test_results"
   CACHE STRING "The path where test results are generated"
 )
 
-if(AMENT_ENABLE_TESTING)
-  enable_testing()
+if(BUILD_TESTING)
   # configure ctest not to truncate the dashboard summary
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.ctest"
     "set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 0)\n"


### PR DESCRIPTION
Instead of using our own option use the one provided by the CTest module.

Since that affects every ament package which has tests I think a single vote on this ticket should be enough (if you don't have a specific comment to any of the other PRs).

* http://ci.ros2.org/view/packaging/job/ci_linux/1244/
* http://ci.ros2.org/view/packaging/job/ci_osx/999/
* http://ci.ros2.org/view/packaging/job/ci_windows/1282/
* http://ci.ros2.org/view/packaging/job/packaging_linux/230/
* http://ci.ros2.org/view/packaging/job/packaging_osx/205/
* http://ci.ros2.org/view/packaging/job/packaging_windows/217/