### PR TITLE
run nosetests with the python executable

### DIFF
--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -70,7 +70,7 @@ function(_ament_add_nose_test testname path)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${testname}.xunit.xml")
   # Invoke ${NOSETESTS} explicitly with the ${PYTHON_EXECUTABLE} because on
-  # some systems, like OS X, the ${NOSETESTS} binay may have a #! which points
+  # some systems, like OS X, the ${NOSETESTS} binary may have a #! which points
   # to the Python2 on the system, rather than the Python3 which is what we want
   # most of the time.
   # This "misalignment" can occur when you do `pip install -U nose` after doing

--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -70,7 +70,7 @@ function(_ament_add_nose_test testname path)
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${testname}.xunit.xml")
   set(cmd
-    "${NOSETESTS}" "${path}" "--with-xunit"
+    "${PYTHON_EXECUTABLE}" "${NOSETESTS}" "${path}" "--with-xunit"
     "--xunit-file=${result_file}")
   if(NOT "${NOSETESTS_VERSION}" VERSION_LESS "1.3.5")
     list(APPEND cmd "--xunit-testsuite-name=${PROJECT_NAME}.nosetests")

--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -69,6 +69,15 @@ function(_ament_add_nose_test testname path)
   endif()
 
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${testname}.xunit.xml")
+  # Invoke ${NOSETESTS} explicitly with the ${PYTHON_EXECUTABLE} because on
+  # some systems, like OS X, the ${NOSETESTS} binay may have a #! which points
+  # to the Python2 on the system, rather than the Python3 which is what we want
+  # most of the time.
+  # This "misalignment" can occur when you do `pip install -U nose` after doing
+  # `pip3 install -U nose` because both install the `nose` binary.
+  # Basically the last Python system to install nose will determine what the
+  # ${NOSETESTS} executable references.
+  # See: https://github.com/ament/ament_cmake/pull/70
   set(cmd
     "${PYTHON_EXECUTABLE}" "${NOSETESTS}" "${path}" "--with-xunit"
     "--xunit-file=${result_file}")


### PR DESCRIPTION
On my system, the binary `nosetests` will use the last version of Python to install (or update) `nose` with `pip`, i.e. it could be for Python2 or Python3.

By invoking it with the python executable, it ensures that the right version is used no matter what. This is also how it's invoked to get the version:

https://github.com/ament/ament_cmake/blob/master/ament_cmake_nose/ament_cmake_nose-extras.cmake#L34