### PR TITLE
add ament_cmake_export_targets

### DIFF
--- a/ament_cmake/CMakeLists.txt
+++ b/ament_cmake/CMakeLists.txt
@@ -13,6 +13,7 @@ ament_export_dependencies(
   "ament_cmake_export_interfaces"
   "ament_cmake_export_libraries"
   "ament_cmake_export_link_flags"
+  "ament_cmake_export_targets"
   "ament_cmake_libraries"
   "ament_cmake_python"
   "ament_cmake_target_dependencies"

--- a/ament_cmake/package.xml
+++ b/ament_cmake/package.xml
@@ -21,6 +21,7 @@
   <build_export_depend>ament_cmake_export_interfaces</build_export_depend>
   <build_export_depend>ament_cmake_export_libraries</build_export_depend>
   <build_export_depend>ament_cmake_export_link_flags</build_export_depend>
+  <build_export_depend>ament_cmake_export_targets</build_export_depend>
   <build_export_depend>ament_cmake_libraries</build_export_depend>
   <build_export_depend>ament_cmake_python</build_export_depend>
   <build_export_depend>ament_cmake_target_dependencies</build_export_depend>

--- a/ament_cmake_export_targets/CMakeLists.txt
+++ b/ament_cmake_export_targets/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ament_cmake_export_targets NONE)
+
+find_package(ament_cmake_core REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "ament_cmake_export_targets-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/ament_cmake_export_targets/ament_cmake_export_targets-extras.cmake
+++ b/ament_cmake_export_targets/ament_cmake_export_targets-extras.cmake
@@ -1,0 +1,30 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from
+# ament_cmake_export_targets/ament_cmake_export_targets-extras.cmake
+
+# register ament_package() hook for targets once
+macro(_ament_cmake_export_targets_register_package_hook)
+  if(NOT DEFINED _AMENT_CMAKE_EXPORT_TARGETS_PACKAGE_HOOK_REGISTERED)
+    set(_AMENT_CMAKE_EXPORT_TARGETS_PACKAGE_HOOK_REGISTERED TRUE)
+
+    find_package(ament_cmake_core QUIET REQUIRED)
+    ament_register_extension("ament_package" "ament_cmake_export_targets"
+      "ament_cmake_export_targets_package_hook.cmake")
+  endif()
+endmacro()
+
+include(
+  "${ament_cmake_export_targets_DIR}/ament_export_targets.cmake")

--- a/ament_cmake_export_targets/cmake/ament_cmake_export_targets-extras.cmake.in
+++ b/ament_cmake_export_targets/cmake/ament_cmake_export_targets-extras.cmake.in
@@ -1,0 +1,7 @@
+# generated from ament_cmake_export_targets/cmake/ament_cmake_export_targets-extras.cmake.in
+
+set(@PROJECT_NAME@_EXPORTED_TARGET_NAMES "@_AMENT_CMAKE_EXPORT_TARGETS@")
+
+foreach(_target IN LISTS @PROJECT_NAME@_EXPORTED_TARGET_NAMES)
+  include("${@PROJECT_NAME@_DIR}/ament_cmake_export_targets-target_${_target}.cmake")
+endforeach()

--- a/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
+++ b/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
@@ -1,0 +1,40 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+foreach(_target IN LISTS _AMENT_CMAKE_EXPORT_TARGETS)
+  # install exported target
+  install(TARGETS ${_target}
+    EXPORT ${_target}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
+
+  # generate and install a CMake file containing code to import target
+  install(
+    EXPORT ${_target}
+    DESTINATION "share/${PROJECT_NAME}/cmake"
+    NAMESPACE "${PROJECT_NAME}::"
+  FILE "ament_cmake_export_targets-target_${_target}.cmake")
+endforeach()
+
+# generate and register extra file for targets
+set(_generated_extra_file
+"${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_export_targets/ament_cmake_export_targets-extras.cmake")
+configure_file(
+  "${ament_cmake_export_targets_DIR}/ament_cmake_export_targets-extras.cmake.in"
+  "${_generated_extra_file}"
+  @ONLY
+)
+
+list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS "${_generated_extra_file}")

--- a/ament_cmake_export_targets/cmake/ament_export_targets.cmake
+++ b/ament_cmake_export_targets/cmake/ament_export_targets.cmake
@@ -1,0 +1,49 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Export targets to downstream packages.
+#
+# Each target name must be valid target.
+# The targets are being installed to `lib` (archive and library) or `bin`
+# (runtime).
+#
+# After being find_package()-ed the variable
+# `<project_name>_EXPORTED_TARGET_NAMES` contains the passed target names.
+# For each target name an imported target with the name
+# `<project_name>::<target_name>` is created.
+#
+# :param ARGN: a list of target names
+# :type ARGN: list of strings
+#
+# @public
+#
+macro(ament_export_targets)
+  if(_${PROJECT_NAME}_AMENT_PACKAGE)
+    message(FATAL_ERROR
+      "ament_export_targets() must be called before ament_package()")
+  endif()
+
+  if(${ARGC} GREATER 0)
+    _ament_cmake_export_targets_register_package_hook()
+    foreach(_arg ${ARGN})
+      # ensure argument is a valid target name
+      if(NOT TARGET "${_arg}")
+        message(FATAL_ERROR
+          "ament_export_targets() argument '${_arg}' is not a target")
+      endif()
+      list(APPEND _AMENT_CMAKE_EXPORT_TARGETS "${_arg}")
+    endforeach()
+  endif()
+endmacro()

--- a/ament_cmake_export_targets/package.xml
+++ b/ament_cmake_export_targets/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_cmake_export_targets</name>
+  <version>0.0.0</version>
+  <description>The ability to export targets to downstream packages in the ament buildsystem in CMake.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Enables exporting targets and making them available as imported targets to downstream packages. The imported target contains all the necessary information (definitions, include dirs, libraries, including transitive dependencies).

See the referenced PR on `ament_index_cpp` for an example.

* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2357)](http://ci.ros2.org/job/ci_linux/2357/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1811)](http://ci.ros2.org/job/ci_osx/1811/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2468)](http://ci.ros2.org/job/ci_windows/2468/)