### PR TITLE
prevent adding the gmock subdirectory twice

### DIFF
--- a/ament_cmake_gmock/ament_cmake_gmock-extras.cmake
+++ b/ament_cmake_gmock/ament_cmake_gmock-extras.cmake
@@ -78,12 +78,16 @@ macro(_ament_cmake_gmock_find_gmock)
       message(STATUS "Found gmock sources under '${GMOCK_FROM_SOURCE_BASE_DIR}': "
         "C++ tests using 'Google Mock' will be built")
 
-      # add CMakeLists.txt from gmock dir
-      add_subdirectory("${GMOCK_FROM_SOURCE_BASE_DIR}" "${CMAKE_BINARY_DIR}/gmock")
+      # if gmock is already a target, do not add again
+      # this can happen when ament_add_gmock() is called from a subdirectory
+      if(NOT TARGET gmock)
+        # add CMakeLists.txt from gmock dir
+        add_subdirectory("${GMOCK_FROM_SOURCE_BASE_DIR}" "${CMAKE_BINARY_DIR}/gmock")
 
-      # mark gmock targets with EXCLUDE_FROM_ALL to only build
-      # when tests are built which depend on them
-      set_target_properties(gmock gmock_main PROPERTIES EXCLUDE_FROM_ALL 1)
+        # mark gmock targets with EXCLUDE_FROM_ALL to only build
+        # when tests are built which depend on them
+        set_target_properties(gmock gmock_main PROPERTIES EXCLUDE_FROM_ALL 1)
+      endif()
 
       # set the same variables as find_package() would set
       # but do NOT set GMOCK_FOUND in the cache when using gmock from source


### PR DESCRIPTION
This is required to prevent an error like this:

```
-- Found gmock sources under '/Users/william/ros2_ws/install/src/gmock_vendor/googlemock-1.7.0': C++ tests using 'Google Mock' will be built
-- Found gmock sources under '/Users/william/ros2_ws/install/src/gmock_vendor/googlemock-1.7.0': C++ tests using 'Google Mock' will be built
CMake Error at /Users/william/ros2_ws/install/share/ament_cmake_gmock/cmake/ament_cmake_gmock-extras.cmake:82 (add_subdirectory):
  The binary directory

    /Users/william/ros2_ws/build/c_utilities/gmock

  is already used to build a source directory.  It cannot be used to build
  source directory

    /Users/william/ros2_ws/install/src/gmock_vendor/googlemock-1.7.0

  Specify a unique binary directory name.
Call Stack (most recent call first):
  /Users/william/ros2_ws/install/share/ament_cmake_gmock/cmake/ament_add_gmock.cmake:46 (_ament_cmake_gmock_find_gmock)
  CMakeLists.txt:64 (ament_add_gmock)

```

Which occurs when you use `ament_add_gmock` from more than one `CMakeLists.txt` in a single project.

`ament_gtest` is protected in a similar fashion, but for a different reason it seems:

https://github.com/ament/ament_cmake/blob/eee011e156a0fa526b204607b6e8bd762800be27/ament_cmake_gtest/ament_cmake_gtest-extras.cmake#L92

Connects to ros2/c_utilities#16