### PR TITLE
Specify package.xml encoding as utf-8

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -39,7 +39,7 @@ def main(argv=sys.argv[1:]):
     )
     parser.add_argument(
         'package_xml',
-        type=argparse.FileType('r'),
+        type=argparse.FileType('r', encoding='utf-8'),
         help='The path to a package.xml file',
     )
     parser.add_argument(


### PR DESCRIPTION
If we rely on the default encoding, you get the following error when trying to parse a package.xml that has utf-8 characters ([this one, for example](https://github.com/ros2/rmw_fastrtps/blob/release-beta1/rmw_fastrtps_cpp/package.xml#L7)) and the default is ascii:

```
-- Found ament_lint_auto: 0.0.0 (/root/ws_ros2/install/share/ament_lint_auto/cmake)
Error parsing '/root/ws_ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/package.xml':
Traceback (most recent call last):
  File "/root/ws_ros2/install/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py", line 141, in <module>
    main()
  File "/root/ws_ros2/install/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py", line 56, in main
    raise e
  File "/root/ws_ros2/install/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py", line 53, in main
    package = parse_package_string(args.package_xml.read())
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 409: ordinal not in range(128)
CMake Error at /root/ws_ros2/install/share/ament_cmake_core/cmake/core/ament_package_xml.cmake:94 (message):
  execute_process(/usr/bin/python3
  /root/ws_ros2/install/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py
  /root/ws_ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/package.xml
  /root/ws_ros2/build/rmw_fastrtps_cpp/ament_cmake_core/package.cmake)
  returned error code 1
Call Stack (most recent call first):
  /root/ws_ros2/install/share/ament_cmake_core/cmake/core/ament_package_xml.cmake:49 (_ament_package_xml)
  /root/ws_ros2/install/share/ament_lint_auto/cmake/ament_lint_auto_find_test_dependencies.cmake:30 (ament_package_xml)
  CMakeLists.txt:72 (ament_lint_auto_find_test_dependencies)
```