### PR TITLE
Install ament_cmake_auto executables to libexec by default

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -17,6 +17,12 @@
 # extension point ``ament_auto_package`` and invoke
 # ``ament_package()``.
 #
+# :param INSTALL_TO_PATH: if set, install targets so that they are
+# on the path. Runtime targets are installed to bin; archive and
+# and library are targets installed to lib. Default is to install
+# all targets to lib/<package_name>.
+# :type INSTALL_TO_PATH: option
+#
 # Export all found build dependencies which are also run
 # dependencies.
 # If the package has an include directory install all recursively
@@ -29,6 +35,12 @@
 #
 
 macro(ament_auto_package)
+  cmake_parse_arguments(_ARG "INSTALL_TO_PATH" "" "" ${ARGN})
+  if(_ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_auto_find_build_dependencies() called with "
+      "unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
   # export all found build dependencies which are also run dependencies
   set(_run_depends
     ${${PROJECT_NAME}_BUILD_EXPORT_DEPENDS}
@@ -61,12 +73,19 @@ macro(ament_auto_package)
 
   # install all executables
   if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
-    install(
-      TARGETS ${${PROJECT_NAME}_EXECUTABLES}
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib
-      RUNTIME DESTINATION bin
-    )
+    if(_ARG_INSTALL_TO_PATH)
+      install(
+        TARGETS ${${PROJECT_NAME}_EXECUTABLES}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+      )
+    else()
+      install(
+        TARGETS ${${PROJECT_NAME}_EXECUTABLES}
+        DESTINATION lib/${PROJECT_NAME}
+      )
+    endif()
   endif()
 
   ament_execute_extensions(ament_auto_package)

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -17,10 +17,13 @@
 # extension point ``ament_auto_package`` and invoke
 # ``ament_package()``.
 #
-# :param INSTALL_TO_PATH: if set, install targets so that they are
-# on the path. Runtime targets are installed to bin; archive and
-# and library are targets installed to lib. Default is to install
-# all targets to lib/<package_name>.
+# :param INSTALL_TO_PATH: if set, install executables to `bin` so that
+#   they are available on the `PATH`.
+#   By default they are being installed into `lib/${PROJECT_NAME}`.
+#   It is currently not possible to install some executable into `bin`
+#   and some into `lib/${PROJECT_NAME}`.
+#   Libraries are not affected by this option.
+#   They are always installed into `lib` and `dll`s into `bin`.
 # :type INSTALL_TO_PATH: option
 #
 # Export all found build dependencies which are also run

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -77,18 +77,14 @@ macro(ament_auto_package)
   # install all executables
   if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
     if(_ARG_INSTALL_TO_PATH)
-      install(
-        TARGETS ${${PROJECT_NAME}_EXECUTABLES}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
-      )
+      set(_destination "bin")
     else()
-      install(
-        TARGETS ${${PROJECT_NAME}_EXECUTABLES}
-        DESTINATION lib/${PROJECT_NAME}
-      )
+      set(_destination "lib/${PROJECT_NAME}")
     endif()
+    install(
+      TARGETS ${${PROJECT_NAME}_EXECUTABLES}
+      DESTINATION ${_destination}
+    )
   endif()
 
   ament_execute_extensions(ament_auto_package)


### PR DESCRIPTION
as discussed in https://github.com/ament/ament_cmake/issues/96

This changes the default to be libexec, and adds an option to install to the path. From what I understand this will only impact packages adding executables with `ament_auto_add_executable`. That I know of (amcl + searching on github in non-forked repos) there's only:
- https://github.com/ros2/navigation/blob/ros2/amcl/CMakeLists.txt
- https://github.com/dirk-thomas/ament_examples/blob/75d6209e4e2db33ad957a2abd1a3a7e102068863/example_auto/CMakeLists.txt
- a few in https://github.com/GroupOfRobots/RysROS2

There may be others, but in general this isn't widely used. I can let the user know of the change in default behaviour.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2881)](http://ci.ros2.org/job/ci_linux/2881/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=372)](http://ci.ros2.org/job/ci_linux-aarch64/372/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2325)](http://ci.ros2.org/job/ci_osx/2325/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3009)](http://ci.ros2.org/job/ci_windows/3009/)
* TB linux (includes amcl) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=82)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/82/)


(none of the CI jobs are really exercising this change, just tested locally)