### PR TITLE
Get nose tests to immediately print console output

### DIFF
--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -84,8 +84,11 @@ function(_ament_add_nose_test testname path)
   # ${NOSETESTS} executable references.
   # See: https://github.com/ament/ament_cmake/pull/70
   set(cmd
-    "${ARG_PYTHON_EXECUTABLE}" "${NOSETESTS}" "${path}" "--with-xunit"
-    "--xunit-file=${result_file}")
+    "${ARG_PYTHON_EXECUTABLE}"
+    "-u"  # unbuffered stdout and stderr
+    "${NOSETESTS}" "${path}"
+    "--nocapture"  # stdout will be printed immediately
+    "--with-xunit" "--xunit-file=${result_file}")
   if(NOT "${NOSETESTS_VERSION}" VERSION_LESS "1.3.5")
     list(APPEND cmd "--xunit-testsuite-name=${PROJECT_NAME}.nosetests")
     if(NOT "${NOSETESTS_VERSION}" VERSION_LESS "1.3.8")


### PR DESCRIPTION
This is useful for tests that timeout and get killed without an opportunity to print the console output that was captured.

Example without this PR (no console output for debugging test timeout):
http://ci.ros2.org/view/nightly/job/nightly_osx_repeated/757/testReport/(root)/projectroot/test_composition__rmw_fastrtps_cpp/

Example with this PR (console output that may be useful for debugging is printed even with timeout):
http://ci.ros2.org/job/ci_osx/2340/testReport/(root)/projectroot/test_composition__rmw_fastrtps_cpp/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2901)](http://ci.ros2.org/job/ci_linux/2901/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=385)](http://ci.ros2.org/job/ci_linux-aarch64/385/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2341)](http://ci.ros2.org/job/ci_osx/2341/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3023)](http://ci.ros2.org/job/ci_windows/3023/)