### PR TITLE
Replace include(CTest) by enable_testing

### DIFF
--- a/ament_cmake_test/ament_cmake_test-extras.cmake
+++ b/ament_cmake_test/ament_cmake_test-extras.cmake
@@ -14,7 +14,7 @@
 
 # copied from ament_cmake_test/ament_cmake_test-extras.cmake
 
-include(CTest)
+enable_testing()
 
 # option()
 set(


### PR DESCRIPTION
Qt Creator 4.3.1 started showing a lot of unnecessary targets in my own project. 
According to this stackoverflow post this comes from using `include(CTest)` instead of `enable_testing`
https://stackoverflow.com/questions/45169854/cmake-in-qtcreator-4-3-shows-many-automatic-targets-how-to-remove-hide-them

Could you please test this PR and consider merging it. I can't test it on my own system because some of the testing infrastructure doesn't work on debian testing.  I tested that it removes not needed targets from being shown in qt creator.