### PR TITLE
merge env values which were split on semicolons

### DIFF
--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -88,19 +88,7 @@ function(ament_add_test testname)
     list(APPEND cmd_wrapper "--output-file" "${ARG_OUTPUT_FILE}")
   endif()
   if(ARG_ENV)
-    list(APPEND cmd_wrapper "--env")
-    foreach(_env ${ARG_ENV})
-      # TODO(wjwwood): remove this when we have a better way to pass PATH lists
-      #   to environment variables on Windows.
-      if(WIN32)
-        # In order to pass a ;-separated list of paths into this function on
-        # Windows, the calling code may have had to replace ;'s to avoid it
-        # them from being interpreted as a CMake list, so undo that
-        # substitution here.
-        string(REPLACE "\;" ";" _env "${_env}")
-      endif()
-      list(APPEND cmd_wrapper "${_env}")
-    endforeach()
+    list(APPEND cmd_wrapper "--env" ${ARG_ENV})
   endif()
   if(ARG_APPEND_LIBRARY_DIRS)
     if(WIN32)
@@ -117,19 +105,7 @@ function(ament_add_test testname)
     endforeach()
   endif()
   if(ARG_APPEND_ENV)
-    list(APPEND cmd_wrapper "--append-env")
-    foreach(_env ${ARG_APPEND_ENV})
-      # TODO(wjwwood): remove this when we have a better way to pass PATH lists
-      #   to environment variables on Windows.
-      if(WIN32)
-        # In order to pass a ;-separated list of paths into this function on
-        # Windows, the calling code may have had to replace ;'s to avoid it
-        # them from being interpreted as a CMake list, so undo that
-        # substitution here.
-        string(REPLACE "\;" ";" _env "${_env}")
-      endif()
-      list(APPEND cmd_wrapper "${_env}")
-    endforeach()
+    list(APPEND cmd_wrapper "--append-env" ${ARG_APPEND_ENV})
   endif()
   list(APPEND cmd_wrapper "--command" ${ARG_COMMAND})
 

--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -129,20 +129,36 @@ def main(argv=sys.argv[1:]):
         env = dict(os.environ)
         if args.env:
             log('-- run_test.py: extra environment variables:')
+            previous_key = None
             for env_str in args.env:
-                key, value = separate_env_vars(env_str, 'env', parser)
+                # if CMake has split a single value containing semicolons
+                # into multiple arguments they are put back together here
+                if previous_key and '=' not in env_str:
+                    key = previous_key
+                    value = env[key] + ';' + env_str
+                else:
+                    key, value = separate_env_vars(env_str, 'env', parser)
                 log(' - {0}={1}'.format(key, value))
                 env[key] = value
+                previous_key = key
         if args.append_env:
             log('-- run_test.py: extra environment variables to append:')
+            previous_key = None
             for env_str in args.append_env:
-                key, value = separate_env_vars(env_str, 'append-env', parser)
+                # if CMake has split a single value containing semicolons
+                # into multiple arguments they are put back together here
+                if previous_key and '=' not in env_str:
+                    key = previous_key
+                    value = env[key] + ';' + env_str
+                else:
+                    key, value = separate_env_vars(env_str, 'append-env', parser)
                 log(' - {0}={1}'.format(key, value))
                 if key not in env:
                     env[key] = ''
                 if not env[key].endswith(os.pathsep):
                     env[key] += os.pathsep
                 env[key] += value
+                previous_key = key
 
     log("-- run_test.py: invoking following command in '%s':\n - %s" %
         (os.getcwd(), ' '.join(args.command)))

--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -130,6 +130,7 @@ def main(argv=sys.argv[1:]):
         if args.env:
             log('-- run_test.py: extra environment variables:')
             previous_key = None
+            updated_env_keys = set()
             for env_str in args.env:
                 # if CMake has split a single value containing semicolons
                 # into multiple arguments they are put back together here
@@ -138,9 +139,11 @@ def main(argv=sys.argv[1:]):
                     value = env[key] + ';' + env_str
                 else:
                     key, value = separate_env_vars(env_str, 'env', parser)
-                log(' - {0}={1}'.format(key, value))
                 env[key] = value
+                updated_env_keys.add(key)
                 previous_key = key
+            for key in updated_env_keys:
+                log(' - {0}={1}'.format(key, env[key]))
         if args.append_env:
             log('-- run_test.py: extra environment variables to append:')
             previous_key = None
@@ -150,9 +153,10 @@ def main(argv=sys.argv[1:]):
                 if previous_key and '=' not in env_str:
                     key = previous_key
                     value = env[key] + ';' + env_str
+                    log(' - {0}+={1}'.format(key, env_str))
                 else:
                     key, value = separate_env_vars(env_str, 'append-env', parser)
-                log(' - {0}={1}'.format(key, value))
+                    log(' - {0}+={1}'.format(key, value))
                 if key not in env:
                     env[key] = ''
                 if not env[key].endswith(os.pathsep):


### PR DESCRIPTION
Fixes #66.

Instead of introducing a custom separator which doesn't collide with semicolon used for list item separation in CMake this patch modifies the Python script to put the separated arguments back together.

The following test job shows the correct passing of such arguments: http://ci.ros2.org/job/ci_windows/3062/consoleFull (search for `foo=bar`).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2935)](http://ci.ros2.org/job/ci_linux/2935/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=402)](http://ci.ros2.org/job/ci_linux-aarch64/402/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2379)](http://ci.ros2.org/job/ci_osx/2379/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3063)](http://ci.ros2.org/job/ci_windows/3063/)