### PR TITLE
Resolve some todos

### DIFF
--- a/ament_cmake_core/cmake/index/ament_cmake_index_package_hook.cmake
+++ b/ament_cmake_core/cmake/index/ament_cmake_index_package_hook.cmake
@@ -14,5 +14,3 @@
 
 # register package name for index
 ament_index_register_package()
-
-# TODO register plugins

--- a/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_prefix_path.cmake
@@ -46,7 +46,6 @@ function(ament_index_get_prefix_path var)
 
   # Remove CMAKE_INSTALL_PREFIX if it is in the list of paths to search,
   # and add it to the list at the front
-  # TODO(dirk-thomas) check if this can be removed or the insert can be done
   list(REMOVE_ITEM prefix_path "${CMAKE_INSTALL_PREFIX}")
   list(INSERT prefix_path 0 "${CMAKE_INSTALL_PREFIX}")
 

--- a/ament_cmake_core/cmake/index/ament_index_get_resources.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_resources.cmake
@@ -54,15 +54,14 @@ function(ament_index_get_resources var resource_type)
   set(all_resources "")
   foreach(path IN LISTS paths_to_search)
     set(resource_index_path "${path}/share/ament_index/resource_index")
-    # TODO use LIST_DIRECTORIES false in GLOB call when available in CMake 3.5
     file(GLOB resources
+      LIST_DIRECTORIES FALSE
       RELATIVE "${resource_index_path}/${resource_type}"
       "${resource_index_path}/${resource_type}/*")
     foreach(resource IN LISTS resources)
       string(SUBSTRING "${resource}" 0 1 resource_char0)
-      # Ignore all subdirectories, and any files starting with a dot
-      if((NOT IS_DIRECTORY "${resource_index_path}/${resource_type}/${resource}") 
-        AND (NOT resource_char0 STREQUAL "."))
+      # Ignore any files starting with a dot
+      if(NOT resource_char0 STREQUAL ".")
         list_append_unique(all_resources ${resource})
       endif()
     endforeach()

--- a/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
+++ b/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
@@ -134,8 +134,7 @@ if(NOT _exported_library_names STREQUAL "")
   endwhile()
 endif()
 
-# deduplicate @PROJECT_NAME@_LIBRARIES
+# TODO(dirk-thomas) deduplicate @PROJECT_NAME@_LIBRARIES
 # while maintaining library order
 # as well as build configuration keywords
 # as well as linker flags
-# TODO

--- a/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries_package_hook.cmake
+++ b/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries_package_hook.cmake
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# deduplicate _AMENT_EXPORT_LIBRARIES and _AMENT_EXPORT_LIBRARY_NAMES
+# TODO(dirk-thomas) deduplicate _AMENT_EXPORT_LIBRARIES and _AMENT_EXPORT_LIBRARY_NAMES
 # while maintaining library order
 # as well as build configuration keywords
 # as well as linker flags
-# TODO
 
 # generate and register extra file for libraries
 set(_generated_extra_file

--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -133,5 +133,3 @@ function(_ament_add_nose_test testname path)
     LABELS "nose"
   )
 endfunction()
-
-# TODO provide function to register all found tests separately

--- a/ament_cmake_python/cmake/ament_python_install_module.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_module.cmake
@@ -20,6 +20,8 @@
 # :param DESTINATION_SUFFIX: the base package to install the module to
 #   (default: empty, install as a top level module)
 # :type DESTINATION_SUFFIX: string
+# :param SKIP_COMPILE: if set do not compile the installed module
+# :type SKIP_COMPILE: option
 #
 macro(ament_python_install_module)
   _ament_cmake_python_register_environment_hook()
@@ -27,7 +29,7 @@ macro(ament_python_install_module)
 endmacro()
 
 function(_ament_cmake_python_install_module module_file)
-  cmake_parse_arguments(ARG "" "DESTINATION_SUFFIX" "" ${ARGN})
+  cmake_parse_arguments(ARG "SKIP_COMPILE" "DESTINATION_SUFFIX" "" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_python_install_module() called with unused "
       "arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -55,7 +57,16 @@ function(_ament_cmake_python_install_module module_file)
     FILES "${module_file}"
     DESTINATION "${destination}"
   )
-  # TODO optionally compile Python file
+  if(NOT ARG_SKIP_COMPILE)
+    # compile Python files
+    install(CODE
+      "execute_process(
+        COMMAND
+        \"${PYTHON_EXECUTABLE}\" \"-m\" \"compileall\"
+        \"${CMAKE_INSTALL_PREFIX}/${destination}/${module_file}\"
+      )"
+    )
+  endif()
 
   if(destination IN_LIST AMENT_CMAKE_PYTHON_INSTALL_INSTALLED_NAMES)
     message(FATAL_ERROR "ament_python_install_module() a Python module file "

--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -20,6 +20,8 @@
 # :param PACKAGE_DIR: the path to the Python package directory (default:
 #   <package_name> folder relative to the CMAKE_CURRENT_LIST_DIR)
 # :type PACKAGE_DIR: string
+# :param SKIP_COMPILE: if set do not compile the installed package
+# :type SKIP_COMPILE: option
 #
 macro(ament_python_install_package)
   _ament_cmake_python_register_environment_hook()
@@ -27,7 +29,7 @@ macro(ament_python_install_package)
 endmacro()
 
 function(_ament_cmake_python_install_package package_name)
-  cmake_parse_arguments(ARG "" "PACKAGE_DIR" "" ${ARGN})
+  cmake_parse_arguments(ARG "SKIP_COMPILE" "PACKAGE_DIR" "" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_python_install_package() called with unused "
       "arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -57,7 +59,16 @@ function(_ament_cmake_python_install_package package_name)
     PATTERN "*.pyc" EXCLUDE
     PATTERN "__pycache__" EXCLUDE
   )
-  # TODO(dirk-thomas): optionally compile Python files
+  if(NOT ARG_SKIP_COMPILE)
+    # compile Python files
+    install(CODE
+      "execute_process(
+        COMMAND
+        \"${PYTHON_EXECUTABLE}\" \"-m\" \"compileall\"
+        \"${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/${package_name}\"
+      )"
+    )
+  endif()
 
   if(package_name IN_LIST AMENT_CMAKE_PYTHON_INSTALL_INSTALLED_NAMES)
     message(FATAL_ERROR


### PR DESCRIPTION
* Remove obsolete `TODO`s
* Move `TODO`s to a line with a comment (rather than an empty line)
* use CMake 3.5 feature (`file(GLOB LIST_DIRECTORIES ...`)
* compile installed Python modules and packages, add option to skip compilation