### PR TITLE
install file and not absolute path

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_module.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_module.cmake
@@ -57,6 +57,7 @@ function(_ament_cmake_python_install_module module_file)
     FILES "${module_file}"
     DESTINATION "${destination}"
   )
+  get_filename_component(module_file "${module_file}" NAME)
   if(NOT ARG_SKIP_COMPILE)
     # compile Python files
     install(CODE


### PR DESCRIPTION
Follow-up of https://github.com/ament/ament_cmake/pull/103.
Absolute path of the module file is appended to the install path resulting in errors such as:
`Can't list '/home/rosbuild/ci_scripts/ws/install/lib/python3.5/site-packages/builtin_interfaces//home/rosbuild/ci_scripts/ws/build/builtin_interfaces/rosidl_generator_py/builtin_interfaces/__init__.py'` in console output of any job since [this job](http://ci.ros2.org/view/packaging/job/packaging_linux/773/consoleFull). This PR passes only the module name resulting in a correct installation path for the module file.