### PR TITLE
inject classname for gtest result files

### DIFF
--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -77,7 +77,8 @@ function(ament_add_test testname)
 
   # wrap command with run_test script to ensure test result generation
   set(cmd_wrapper "${PYTHON_EXECUTABLE}" "-u" "${ament_cmake_test_DIR}/run_test.py"
-    "${ARG_RESULT_FILE}")
+    "${ARG_RESULT_FILE}"
+    "--package-name" "${PROJECT_NAME}")
   if(ARG_SKIP_TEST)
     list(APPEND cmd_wrapper "--skip-test")
   endif()


### PR DESCRIPTION
Sadly `gtest` doesn't offer a way to customize the `classname` attribute which is used by Jenkins `xunit` to create the hierarchy. Therefore I chose to modify the generated gtest result files.

Before the `gtest` results were under the `(root)` entry with no indication to the package: http://ci.ros2.org/job/ci_linux/3531/testReport/(root)/

After they are under an entry names after the package: http://ci.ros2.org/job/ci_linux/3540/testReport/ament_index_cpp/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3541)](http://ci.ros2.org/job/ci_linux/3541/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=748)](http://ci.ros2.org/job/ci_linux-aarch64/748/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2888)](http://ci.ros2.org/job/ci_osx/2888/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3618)](http://ci.ros2.org/job/ci_windows/3618/)