### PR TITLE
populate GROUP_DEPENDS and MEMBER_OF_GROUPS cmake variables

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -109,6 +109,10 @@ def generate_cmake_code(package):
                                            package.exec_depends))
     variables.extend(get_dependency_values('TEST_DEPENDS',
                                            package.test_depends))
+    variables.extend(get_dependency_values('GROUP_DEPENDS',
+                                           package.group_depends))
+    variables.extend(get_dependency_values('MEMBER_OF_GROUPS',
+                                           package.member_of_groups))
 
     deprecated = [e.content for e in package.exports
                   if e.tagname == 'deprecated']


### PR DESCRIPTION
The `MEMBER_OF_GROUPS` population is necessary to enforce interface packages exporting group membership when installing interfaces.
I added `GROUP_DEPENDS` to the mix as this would otherwise be the only dependency type not available via cmake.