### PR TITLE
Fix python unittest runtime error in ament_cmake

### DIFF
--- a/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
+++ b/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
@@ -82,8 +82,6 @@ function(ament_add_pytest_test testname path)
     "-u"  # unbuffered stdout and stderr
     "-m" "pytest"
     "${path}"
-    # store last failed tests
-    "-o" "cache_dir=${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_pytest/${testname}/.cache"
     # junit arguments
     "--junit-xml=${result_file}"
     "--junit-prefix=${PROJECT_NAME}"


### PR DESCRIPTION
Fix python unittest runtime error due to no support to option `-o` in `python3-pytest`

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>