### PR TITLE
export library path for library interfaces

### DIFF
--- a/ament_cmake_export_interfaces/cmake/ament_export_interfaces.cmake
+++ b/ament_cmake_export_interfaces/cmake/ament_export_interfaces.cmake
@@ -19,8 +19,8 @@
 # ``install(TARGETS ... EXPORT name ...)``.
 # The ``install(EXPORT ...)`` invocation is handled by this macros.
 #
-# :param HAS_LIBRARY_TARGET: if set, an environment variable is being defined
-#   to find the library at runtime executables
+# :param HAS_LIBRARY_TARGET: if set, an environment variable will be defined
+#   so that the library can be found at runtime
 # :type HAS_LIBRARY_TARGET: option
 # :param ARGN: a list of export names
 # :type ARGN: list of strings

--- a/ament_cmake_export_interfaces/cmake/ament_export_interfaces.cmake
+++ b/ament_cmake_export_interfaces/cmake/ament_export_interfaces.cmake
@@ -19,6 +19,9 @@
 # ``install(TARGETS ... EXPORT name ...)``.
 # The ``install(EXPORT ...)`` invocation is handled by this macros.
 #
+# :param HAS_LIBRARY_TARGET: if set, an environment variable is being defined
+#   to find the library at runtime executables
+# :type HAS_LIBRARY_TARGET: option
 # :param ARGN: a list of export names
 # :type ARGN: list of strings
 #
@@ -29,11 +32,19 @@ macro(ament_export_interfaces)
     message(FATAL_ERROR
       "ament_export_interfaces() must be called before ament_package()")
   endif()
+  cmake_parse_arguments(_ARG "HAS_LIBRARY_TARGET" "" "" ${ARGN})
 
   if(${ARGC} GREATER 0)
     _ament_cmake_export_interfaces_register_package_hook()
-    foreach(_arg ${ARGN})
+    foreach(_arg ${_ARG_UNPARSED_ARGUMENTS})
       list(APPEND _AMENT_CMAKE_EXPORT_INTERFACES "${_arg}")
     endforeach()
+
+    # if the export name contains is a library target
+    # make sure to register an environment hook
+    if(${_ARG_HAS_LIBRARY_TARGET})
+      find_package(ament_cmake_export_libraries QUIET REQUIRED)
+      _ament_cmake_export_libraries_register_environment_hook()
+    endif()
   endif()
 endmacro()

--- a/ament_cmake_export_interfaces/package.xml
+++ b/ament_cmake_export_interfaces/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_core</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_export_libraries</buildtool_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Fixes #132. Connect to #132.

CI builds (without repeating tests):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4382)](http://ci.ros2.org/job/ci_linux/4382/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1337)](http://ci.ros2.org/job/ci_linux-aarch64/1337/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3578)](http://ci.ros2.org/job/ci_osx/3578/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4434)](http://ci.ros2.org/job/ci_windows/4434/)