### PR TITLE
Always write generated cmake as utf8

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2014-2015 Source Robotics Foundation, Inc.
+# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+# Copyright 2014-2015 
+Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +58,7 @@ def main(argv=sys.argv[1:]):
 
     lines = generate_cmake_code(package)
     if args.outfile:
-        with open(args.outfile, 'w') as f:
+        with open(args.outfile, 'w', encoding='UTF-8') as f:
             for line in lines:
                 f.write('%s\n' % line)
     else:

--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2014-2015 
-Source Robotics Foundation, Inc.
+# Copyright 2014-2015 Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -57,7 +57,7 @@ def main(argv=sys.argv[1:]):
 
     lines = generate_cmake_code(package)
     if args.outfile:
-        with open(args.outfile, 'w', encoding='UTF-8') as f:
+        with open(args.outfile, 'w', encoding='utf-8') as f:
             for line in lines:
                 f.write('%s\n' % line)
     else:

--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -39,7 +39,7 @@ def main(argv=sys.argv[1:]):
     )
     parser.add_argument(
         'package_xml',
-        type=argparse.FileType('r'),
+        type=argparse.FileType('r', encoding='utf-8'),
         help='The path to a package.xml file',
     )
     parser.add_argument(


### PR DESCRIPTION
CMake documentation suggests that we should be writing 7-bit ascii CMake source files or writing UTF-8 with a byte order mark. (Source: https://cmake.org/cmake/help/v3.5/manual/cmake-language.7.html#encoding).

This doesn't actually do either of those things. It just cements our position of non-compliance (writing utf-8 without a byte order mark) so that builds don't crash if the system encoding is other than utf-8.

Alternatively we could sanitize the generated CMake content so it is 7-bit ascii and explicitly write it as such or consider adding the byte order mark.

This aims to resolve issues like https://github.com/ros2/rmw_fastrtps/issues/193 and https://github.com/ros2/rmw_fastrtps/issues/181