### PR TITLE
use catkin_pkg to parse manifests

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -18,12 +18,7 @@ import argparse
 from collections import OrderedDict
 import sys
 
-try:
-    from ament_package import parse_package_string
-except ImportError as e:
-    sys.exit("ImportError: 'from ament_package import parse_package_string' "
-             "failed: %s\nMake sure that you have installed 'ament_package', "
-             'it is up to date and on the PYTHONPATH.' % e)
+from catkin_pkg.package import parse_package_string
 
 
 def main(argv=sys.argv[1:]):
@@ -50,7 +45,8 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
 
     try:
-        package = parse_package_string(args.package_xml.read())
+        package = parse_package_string(
+            args.package_xml.read(), filename=args.package_xml.name)
     except Exception as e:
         print("Error parsing '%s':" % args.package_xml.name, file=sys.stderr)
         raise e
@@ -87,7 +83,7 @@ def generate_cmake_code(package):
     """
     Return a list of CMake set() commands containing the manifest information.
 
-    :param package: ament_package.Package
+    :param package: catkin_pkg.package.Package
     :returns: list of str
     """
     variables = []

--- a/ament_cmake_core/package.xml
+++ b/ament_cmake_core/package.xml
@@ -18,9 +18,11 @@
 
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>ament_package</buildtool_depend>
+  <buildtool_depend>python3-catkin-pkg-modules</buildtool_depend>
 
   <buildtool_export_depend>cmake</buildtool_export_depend>
   <buildtool_export_depend>ament_package</buildtool_export_depend>
+  <buildtool_export_depend>python3-catkin-pkg-modules</buildtool_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Similar to ros2/ros2cli#94.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4516)](https://ci.ros2.org/job/ci_linux/4516/)

The remaining usage of `ament_package` in this repo (as well as in the whole ROS 2 code base) only accesses the templates stored in that package: https://github.com/ament/ament_cmake/blob/257c2931f3647e74bdbcf3401a286cca5dcb75b9/ament_cmake_core/cmake/package_templates/templates_2_cmake.py#L21-L25

In a follow up ticket this can either handled either way:
* the templates could be moved into `ament_cmake_core`
* everything beside the templates could be removed from `ament_package` (at which point the name should maybe be reconsidered).