### PR TITLE
fix using uninitialized CMake variables

### DIFF
--- a/ament_cmake_core/cmake/core/ament_package.cmake
+++ b/ament_cmake_core/cmake/core/ament_package.cmake
@@ -81,13 +81,20 @@ function(_ament_package)
 
   # expand and install config extras
   set(PACKAGE_CONFIG_EXTRA_FILES "")
-  foreach(
-    extra
-    ${PACKAGE_CONFIG_EXTRAS}
-    ${${PROJECT_NAME}_CONFIG_EXTRAS}
-    ${${PROJECT_NAME}_CONFIG_EXTRAS_POST}
-    ${PACKAGE_CONFIG_EXTRAS_POST}
-  )
+  set(extras)
+  if(DEFINED PACKAGE_CONFIG_EXTRAS)
+    list(APPEND extras ${PACKAGE_CONFIG_EXTRAS})
+  endif()
+  if(DEFINED ${PROJECT_NAME}_CONFIG_EXTRAS)
+    list(APPEND extras ${${PROJECT_NAME}_CONFIG_EXTRAS})
+  endif()
+  if(DEFINED ${PROJECT_NAME}_CONFIG_EXTRAS_POST)
+    list(APPEND extras ${${PROJECT_NAME}_CONFIG_EXTRAS_POST})
+  endif()
+  if(DEFINED PACKAGE_CONFIG_EXTRAS_POST)
+    list(APPEND extras ${PACKAGE_CONFIG_EXTRAS_POST})
+  endif()
+  foreach(extra ${extras})
     assert_file_exists("${extra}"
       "ament_package() called with extra file '${extra}' which does not exist")
     stamp("${extra}")

--- a/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
@@ -49,7 +49,10 @@ function(ament_generate_package_environment)
 
       # collect package hooks to be sourced for this extension
       set(ENVIRONMENT_HOOKS "")
-      if(NOT "${_AMENT_CMAKE_ENVIRONMENT_HOOKS_${extension}}" STREQUAL "")
+      if(
+        DEFINED _AMENT_CMAKE_ENVIRONMENT_HOOKS_${extension} AND
+        NOT "${_AMENT_CMAKE_ENVIRONMENT_HOOKS_${extension}}" STREQUAL ""
+      )
         list(SORT _AMENT_CMAKE_ENVIRONMENT_HOOKS_${extension})
         foreach(hook ${_AMENT_CMAKE_ENVIRONMENT_HOOKS_${extension}})
           set(native_hook "/${hook}")


### PR DESCRIPTION
Otherwise being flagged when invoking with `--warn-uninitialized`.