### PR TITLE
fix wrong FOUND flag on repeated inclusion

### DIFF
--- a/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
+++ b/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
@@ -2,6 +2,15 @@
 
 # prevent multiple inclusion
 if(_@PROJECT_NAME@_CONFIG_INCLUDED)
+  # ensure to keep the found flag the same
+  if(NOT DEFINED @PROJECT_NAME@_FOUND)
+    message(FATAL_ERROR
+      "@PROJECT_NAME@_FOUND is undefined even though the config has been included before")
+  endif()
+  if(NOT @PROJECT_NAME@_FOUND)
+    # explicitly set it to FALSE, otherwise CMake will set it to TRUE
+    set(@PROJECT_NAME@_FOUND FALSE)
+  endif()
   return()
 endif()
 set(_@PROJECT_NAME@_CONFIG_INCLUDED TRUE)

--- a/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
+++ b/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
@@ -4,11 +4,10 @@
 if(_@PROJECT_NAME@_CONFIG_INCLUDED)
   # ensure to keep the found flag the same
   if(NOT DEFINED @PROJECT_NAME@_FOUND)
-    message(FATAL_ERROR
-      "@PROJECT_NAME@_FOUND is undefined even though the config has been included before")
-  endif()
-  if(NOT @PROJECT_NAME@_FOUND)
     # explicitly set it to FALSE, otherwise CMake will set it to TRUE
+    set(@PROJECT_NAME@_FOUND FALSE)
+  elseif(NOT @PROJECT_NAME@_FOUND)
+    # use separate condition to avoid uninitialized variable warning
     set(@PROJECT_NAME@_FOUND FALSE)
   endif()
   return()


### PR DESCRIPTION
Without this patch if a first find of a package sets the `FOUND` flag to `FALSE` a repeated find would set the flag to `TRUE` (which happens implicitly by CMake). While setting it explicitly to `FALSE` in a CMake config file results in a CMake warning that is at least better then setting the wrong flag.

The first condition to check if the variable is actually being defined can only fail if the variable was set explicitly manually (which should never be the case) or when the CMake config file is being included recursive (which shouldn't be done, ros2/rmw_implementation#44 fixes that case for the `rmw_implementation` package).

A fat archive with these changes is available from this build: https://ci.ros2.org/job/ci_packaging_linux/126/

Connect to ros2/ros2#544.