### PR TITLE
only add existing directories to PATH

### DIFF
--- a/ament_cmake_core/cmake/environment_hooks/environment/path.bat
+++ b/ament_cmake_core/cmake/environment_hooks/environment/path.bat
@@ -1,7 +1,7 @@
 :: copied from ament_cmake_core/cmake/environment_hooks/environment/path.bat
 @echo off
 
-call:ament_prepend_unique_value PATH "%AMENT_CURRENT_PREFIX%\bin"
+if exist "%AMENT_CURRENT_PREFIX%\bin" call:ament_prepend_unique_value PATH "%AMENT_CURRENT_PREFIX%\bin"
 
 goto:eof
 

--- a/ament_cmake_core/cmake/environment_hooks/environment/path.sh
+++ b/ament_cmake_core/cmake/environment_hooks/environment/path.sh
@@ -1,3 +1,5 @@
 # copied from ament_cmake_core/cmake/environment_hooks/environment/path.sh
 
-ament_prepend_unique_value PATH "$AMENT_CURRENT_PREFIX/bin"
+if [ -d "$AMENT_CURRENT_PREFIX/bin" ]; then
+  ament_prepend_unique_value PATH "$AMENT_CURRENT_PREFIX/bin"
+fi


### PR DESCRIPTION
The `PATH` environment hook is being added [unconditionally](https://github.com/ament/ament_cmake/blob/7ab62a83055f7a14de9f2e65f60e166a99752eeb/ament_cmake_core/cmake/environment_hooks/ament_cmake_environment_hooks_package_hook.cmake#L22) since we don't have reasonable way to check if any binaries are being installed into `<install>/bin`. This patch at least keeps it a little bit shorter (when installing in isolation) by not adding not existing directories.