### PR TITLE
Use enable_testing() instead of include(CTest)

### DIFF
--- a/ament_cmake_test/ament_cmake_test-extras.cmake
+++ b/ament_cmake_test/ament_cmake_test-extras.cmake
@@ -14,7 +14,7 @@
 
 # copied from ament_cmake_test/ament_cmake_test-extras.cmake
 
-include(CTest)
+enable_testing()
 
 # option()
 set(


### PR DESCRIPTION
- include(CTest) enables CTest and CDash
- CDash creates a lot of targets (ContinuousBuild, NightlyTest, etc.) which are not needed
- enable_testing() enables CTest without CDash

See also https://stackoverflow.com/questions/45169854/cmake-in-qtcreator-4-3-shows-many-automatic-targets-how-to-remove-hide-them