### PR TITLE
use enable_testing() insted of CTest module

### DIFF
--- a/ament_cmake_test/ament_cmake_test-extras.cmake
+++ b/ament_cmake_test/ament_cmake_test-extras.cmake
@@ -14,7 +14,9 @@
 
 # copied from ament_cmake_test/ament_cmake_test-extras.cmake
 
-include(CTest)
+enable_testing()
+# same option as in the CTest module
+option(BUILD_TESTING "Build the testing tree." ON)
 
 # option()
 set(
@@ -24,9 +26,14 @@ set(
 
 if(BUILD_TESTING)
   # configure ctest not to truncate the dashboard summary
-  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.ctest"
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.cmake"
     "set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 0)\n"
     "set(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 0)\n")
+  # create dart configuration from template
+  site_name(SITE)
+  configure_file(
+    ${CMAKE_ROOT}/Modules/DartConfiguration.tcl.in
+    ${PROJECT_BINARY_DIR}/CTestConfiguration.ini )
 endif()
 
 find_package(ament_cmake_core QUIET REQUIRED)


### PR DESCRIPTION
Closes #151.

The only functional difference (afaik) is that the expanded template `DartConfiguration.tcl.in` doesn't have the CMake variable `BUILDNAME` set which results in the `Test.xml` file to contain an empty build name:

> `<Site BuildName="(empty)" ...`

While values like `SITE` are easy to obtain the logic to determine the build name is not exposes through API but embedded into the `CTest` module. I don't think it is necessary to duplicate it.