### PR TITLE
Add ament_cmake_core function to get install path of resource

### DIFF
--- a/ament_cmake_core/ament_cmake_index-extras.cmake
+++ b/ament_cmake_core/ament_cmake_index-extras.cmake
@@ -17,6 +17,7 @@
 include("${ament_cmake_core_DIR}/index/ament_index_get_prefix_path.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_get_resource.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_get_resources.cmake")
+include("${ament_cmake_core_DIR}/index/ament_index_get_resource_prefix_path.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_has_resource.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_register_package.cmake")
 include("${ament_cmake_core_DIR}/index/ament_index_register_resource.cmake")

--- a/ament_cmake_core/cmake/index/ament_index_get_resource_prefix_path.cmake
+++ b/ament_cmake_core/cmake/index/ament_index_get_resource_prefix_path.cmake
@@ -1,0 +1,62 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Get the path to a specified resource's install directory.
+#
+# :param var: the output variable name for the path to the resource's
+#   installation prefix directory
+# :type var: string
+# :param resource_type: the type of the resource
+# :type resource_type: string
+# :param resource_name: the name of the resource
+# :type resource_name: string
+# :param PREFIX_PATH: the prefix path to search for (default
+#   ``ament_index_get_prefix_path()``).
+# :type PREFIX_PATH: list of strings
+#
+# @public
+#
+function(ament_index_get_resource_prefix_path var resource_type resource_name)
+  if(resource_type STREQUAL "")
+    message(FATAL_ERROR
+      "ament_index_get_resource_prefix_path() called without a 'resource_type'")
+  endif()
+  if(resource_name STREQUAL "")
+    message(FATAL_ERROR
+      "ament_index_get_resource_prefix_path() called without a 'resource_name'")
+  endif()
+
+  cmake_parse_arguments(ARG "" "PREFIX_PATH" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_index_get_resource_prefix_path() called with unused "
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(ARG_PREFIX_PATH)
+    set(prefix_path "${ARG_PREFIX_PATH}")
+  else()
+    ament_index_get_prefix_path(prefix_path)
+  endif()
+
+  set(retval FALSE)
+  foreach(path IN LISTS prefix_path)
+    if(EXISTS
+        "${path}/share/ament_index/resource_index/${resource_type}/${resource_name}")
+      set(retval ${path})
+      break()
+    endif()
+  endforeach()
+  set(${var} "${retval}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
 - Parity with ament_index_python function get_package_prefix(package_name)

Need a way to do [this](https://github.com/ament/ament_index/blob/master/ament_index_python/ament_index_python/packages.py#L36) but from a CMakeLists file.  [ament_cmake_index_has_resource](https://github.com/pbaughman/ament_cmake/blob/4ba7544643ef9af35fea1ad47587a0a1bbced921/ament_cmake_core/cmake/index/ament_index_has_resource.cmake) is close, but doesn't tell you the path - it just tells you that the resource exists