### PR TITLE
fix behavior of ament_include_directories_order on non-Windows

### DIFF
--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -23,7 +23,11 @@
 # @public
 #
 macro(ament_include_directories_order var)
-  _ament_include_directories_order(${var} "$ENV{AMENT_PREFIX_PATH}" ${ARGN})
+  set(_ament_prefix_path_list "$ENV{AMENT_PREFIX_PATH}")
+  if(NOT WIN32)
+    string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")
+  endif()
+  _ament_include_directories_order(${var} "${_ament_prefix_path_list}" ${ARGN})
 endmacro()
 
 


### PR DESCRIPTION
Based on https://answers.ros.org/question/315794/precedence-of-colcon_ws-rclcpp-over-optroscrystal-version/