### PR TITLE
Add option to ament_auto_package to install to share folder:

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -25,6 +25,9 @@
 #   Libraries are not affected by this option.
 #   They are always installed into `lib` and `dll`s into `bin`.
 # :type INSTALL_TO_PATH: option
+# :param INSTALL_TO_SHARE: a list of directories to be installed to the
+#   package's share directory
+# :type INSTALL_TO_SHARE: list of strings
 #
 # Export all found build dependencies which are also run
 # dependencies.
@@ -38,7 +41,7 @@
 #
 
 macro(ament_auto_package)
-  cmake_parse_arguments(_ARG "INSTALL_TO_PATH" "" "" ${ARGN})
+  cmake_parse_arguments(_ARG "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_auto_find_build_dependencies() called with "
       "unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
@@ -86,6 +89,14 @@ macro(ament_auto_package)
       DESTINATION ${_destination}
     )
   endif()
+
+  # install directories to share
+  foreach(_dir ${_ARG_INSTALL_TO_SHARE})
+    install(
+      DIRECTORY "${_dir}"
+      DESTINATION "share/${PROJECT_NAME}"
+    )
+  endforeach()
 
   ament_execute_extensions(ament_auto_package)
 


### PR DESCRIPTION
- This will simplify installing folders like 'cmake' and 'launch'
into a package's shared folder
- Currently, none of the ROS 2 packages using ament_auto_package have this use-case, but if it makes sense, I could convert a package, such as `demo_nodes_cpp` that is installing `launch` into `share` as an example of this feature