### PR TITLE
Fix unused-arg check in ament_cmake packages:

### DIFF
--- a/ament_cmake_gmock/cmake/ament_find_gmock.cmake
+++ b/ament_cmake_gmock/cmake/ament_find_gmock.cmake
@@ -24,9 +24,10 @@
 # @public
 #
 macro(ament_find_gmock)
-  if(ARGN)
+  set(_ARGN "${ARGN}")
+  if(_ARGN)
     message(FATAL_ERROR
-      "ament_find_gmock() called with unused arguments: ${ARGN}")
+      "ament_find_gmock() called with unused arguments: ${_ARGN}")
   endif()
   _ament_cmake_gmock_find_gmock()
 endmacro()

--- a/ament_cmake_gtest/cmake/ament_find_gtest.cmake
+++ b/ament_cmake_gtest/cmake/ament_find_gtest.cmake
@@ -25,9 +25,10 @@
 # @public
 #
 macro(ament_find_gtest)
-  if(ARGN)
+  set(_ARGN "${ARGN}")
+  if(_ARGN)
     message(FATAL_ERROR
-      "ament_find_gtest() called with unused arguments: ${ARGN}")
+      "ament_find_gtest() called with unused arguments: ${_ARGN}")
   endif()
   _ament_cmake_gtest_find_gtest()
 endmacro()

--- a/ament_cmake_nose/cmake/ament_find_nosetests.cmake
+++ b/ament_cmake_nose/cmake/ament_find_nosetests.cmake
@@ -21,9 +21,10 @@
 # @public
 #
 macro(ament_find_nose)
-  if(ARGN)
+  set(_ARGN "${ARGN}")
+  if(_ARGN)
     message(FATAL_ERROR
-      "ament_find_nose() called with unused arguments: ${ARGN}")
+      "ament_find_nose() called with unused arguments: ${_ARGN}")
   endif()
   _ament_cmake_nose_find_nosetests()
 endmacro()


### PR DESCRIPTION
Arguments to a macro are not variables, so it's not
possible to do 'if(ARGN)' to check for arguments;
however, copying ARGN to a variable works.

See https://cmake.org/cmake/help/v3.5/command/if.html (emphasis mine):

> if(<variable|string>)
True if given a variable that is defined to a value that is not a false constant. False otherwise. **(Note macro arguments are not variables.)**

- See also ament/ament_lint#136