### PR TITLE
Treat warnings as errors in pytests

### DIFF
--- a/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
+++ b/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
@@ -28,6 +28,8 @@
 # :param TIMEOUT: the test timeout in seconds,
 #   default defined by ``ament_add_test()``
 # :type TIMEOUT: integer
+# :param WERROR: If ON, then treat warnings as errors. Default: ON.
+# :type WERROR: bool
 # :param WORKING_DIRECTORY: the working directory for invoking the
 #   command in, default defined by ``ament_add_test()``
 # :type WORKING_DIRECTORY: string
@@ -45,7 +47,7 @@
 function(ament_add_pytest_test testname path)
   cmake_parse_arguments(ARG
     "SKIP_TEST"
-    "PYTHON_EXECUTABLE;TIMEOUT;WORKING_DIRECTORY"
+    "PYTHON_EXECUTABLE;TIMEOUT;WERROR;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
     ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
@@ -76,6 +78,10 @@ function(ament_add_pytest_test testname path)
     return()
   endif()
 
+  if(NOT DEFINED ARG_WERROR)
+    set(ARG_WERROR ON)
+  endif()
+
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${testname}.xunit.xml")
   set(cmd
     "${ARG_PYTHON_EXECUTABLE}"
@@ -87,9 +93,12 @@ function(ament_add_pytest_test testname path)
     # junit arguments
     "--junit-xml=${result_file}"
     "--junit-prefix=${PROJECT_NAME}"
-    # treat warnings as errors
-    "-We"
   )
+
+  if(ARG_WERROR)
+    # treat warnings as errors
+    list(APPEND cmd "-We")
+  endif()
 
   if(ARG_ENV)
     set(ARG_ENV "ENV" ${ARG_ENV})

--- a/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
+++ b/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
@@ -91,7 +91,7 @@ function(ament_add_pytest_test testname path)
     "--junit-prefix=${PROJECT_NAME}"
   )
 
-  if(DEFINED ARG_WERROR AND ARG_WERROR)
+  if(ARG_WERROR)
     # treat warnings as errors
     list(APPEND cmd "-We")
   endif()

--- a/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
+++ b/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
@@ -28,7 +28,7 @@
 # :param TIMEOUT: the test timeout in seconds,
 #   default defined by ``ament_add_test()``
 # :type TIMEOUT: integer
-# :param WERROR: If ON, then treat warnings as errors. Default: ON.
+# :param WERROR: If ON, then treat warnings as errors. Default: OFF.
 # :type WERROR: bool
 # :param WORKING_DIRECTORY: the working directory for invoking the
 #   command in, default defined by ``ament_add_test()``
@@ -78,10 +78,6 @@ function(ament_add_pytest_test testname path)
     return()
   endif()
 
-  if(NOT DEFINED ARG_WERROR)
-    set(ARG_WERROR ON)
-  endif()
-
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${testname}.xunit.xml")
   set(cmd
     "${ARG_PYTHON_EXECUTABLE}"
@@ -95,7 +91,7 @@ function(ament_add_pytest_test testname path)
     "--junit-prefix=${PROJECT_NAME}"
   )
 
-  if(ARG_WERROR)
+  if(DEFINED ARG_WERROR AND ARG_WERROR)
     # treat warnings as errors
     list(APPEND cmd "-We")
   endif()

--- a/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
+++ b/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
@@ -87,6 +87,8 @@ function(ament_add_pytest_test testname path)
     # junit arguments
     "--junit-xml=${result_file}"
     "--junit-prefix=${PROJECT_NAME}"
+    # treat warnings as errors
+    "-We"
   )
 
   if(ARG_ENV)


### PR DESCRIPTION
This has the benefit of making deprecation warnings visible, which are not by default.