### PR TITLE
close file handle early

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -50,6 +50,8 @@ def main(argv=sys.argv[1:]):
     except Exception as e:
         print("Error parsing '%s':" % args.package_xml.name, file=sys.stderr)
         raise e
+    finally:
+        args.package_xml.close()
 
     lines = generate_cmake_code(package)
     if args.outfile:


### PR DESCRIPTION
Instead of relying on being closed on interpreter shutdown.

Fixes warning mentioned in ros2/build_cop#204.

* Windows `rclpy`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7020)](https://ci.ros2.org/job/ci_windows/7020/)