### PR TITLE
close output_handle explicitly

### DIFF
--- a/ament_cmake_test/cmake/run_test.py
+++ b/ament_cmake_test/cmake/run_test.py
@@ -110,13 +110,22 @@ def main(argv=sys.argv[1:]):
 
     # collect output / exception to generate more detailed result file
     # if the command fails to generate it
-    output = ''
     output_handle = None
     if args.output_file:
         output_path = os.path.dirname(args.output_file)
         if not os.path.exists(output_path):
             os.makedirs(output_path)
         output_handle = open(args.output_file, 'wb')
+
+    try:
+        return _run_test(parser, args, failure_result_file, output_handle)
+    finally:
+        if output_handle:
+            output_handle.close()
+
+
+def _run_test(parser, args, failure_result_file, output_handle):
+    output = ''
 
     def log(msg, **kwargs):
         print(msg, **kwargs)


### PR DESCRIPTION
Follow up of https://github.com/ament/ament_cmake/pull/170#issuecomment-495449482. Actually fixes the warning mentioned in ros2/build_cop#204.

Full set of CI just to make sure there are no regressions:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7217)](http://ci.ros2.org/job/ci_linux/7217/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3415)](http://ci.ros2.org/job/ci_linux-aarch64/3415/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5911)](http://ci.ros2.org/job/ci_osx/5911/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7042)](http://ci.ros2.org/job/ci_windows/7042/)