### PR TITLE
Add 'runner' option to ament_add_gmock / nose

### DIFF
--- a/ament_cmake_gmock/cmake/ament_add_gmock.cmake
+++ b/ament_cmake_gmock/cmake/ament_add_gmock.cmake
@@ -22,6 +22,8 @@
 # :type target: string
 # :param ARGN: the list of source files
 # :type ARGN: list of strings
+# :param RUNNER: the path to the test runner script (default: see ament_add_test).
+# :type RUNNER: string
 # :param TIMEOUT: the test timeout in seconds,
 #   default defined by ``ament_add_test()``
 # :type TIMEOUT: integer
@@ -54,7 +56,7 @@ endmacro()
 function(_ament_add_gmock target)
   cmake_parse_arguments(ARG
     "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
-    "TIMEOUT;WORKING_DIRECTORY"
+    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
     ${ARGN})
   if(NOT ARG_UNPARSED_ARGUMENTS)
@@ -88,6 +90,9 @@ function(_ament_add_gmock target)
   if(ARG_SKIP_TEST)
     set(ARG_SKIP_TEST "SKIP_TEST")
   endif()
+  if(ARG_RUNNER)
+    set(ARG_RUNNER "RUNNER" ${ARG_RUNNER})
+  endif()
   if(ARG_TIMEOUT)
     set(ARG_TIMEOUT "TIMEOUT" ${ARG_TIMEOUT})
   endif()
@@ -100,6 +105,7 @@ function(_ament_add_gmock target)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_gmock/${target}.txt"
     RESULT_FILE "${result_file}"
+    ${ARG_RUNNER}
     ${ARG_ENV}
     ${ARG_APPEND_ENV}
     ${ARG_APPEND_LIBRARY_DIRS}

--- a/ament_cmake_nose/cmake/ament_add_nose_test.cmake
+++ b/ament_cmake_nose/cmake/ament_add_nose_test.cmake
@@ -25,6 +25,8 @@
 # :param PYTHON_EXECUTABLE: absolute path to the executable used to run the test,
 #   default to the CMake variable with the same name returned by FindPythonInterp
 # :type PYTHON_EXECUTABLE: string
+# :param RUNNER: the path to the test runner script (default: see ament_add_test).
+# :type RUNNER: string
 # :param TIMEOUT: the test timeout in seconds,
 #   default defined by ``ament_add_test()``
 # :type TIMEOUT: integer
@@ -52,7 +54,7 @@ endmacro()
 function(_ament_add_nose_test testname path)
   cmake_parse_arguments(ARG
     "SKIP_TEST"
-    "PYTHON_EXECUTABLE;TIMEOUT;WORKING_DIRECTORY"
+    "PYTHON_EXECUTABLE;RUNNER;TIMEOUT;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
     ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
@@ -105,6 +107,9 @@ function(_ament_add_nose_test testname path)
   if(ARG_APPEND_LIBRARY_DIRS)
     set(ARG_APPEND_LIBRARY_DIRS "APPEND_LIBRARY_DIRS" ${ARG_APPEND_LIBRARY_DIRS})
   endif()
+  if(ARG_RUNNER)
+    set(ARG_RUNNER "RUNNER" ${ARG_RUNNER})
+  endif()
   if(ARG_TIMEOUT)
     set(ARG_TIMEOUT "TIMEOUT" "${ARG_TIMEOUT}")
   endif()
@@ -120,6 +125,7 @@ function(_ament_add_nose_test testname path)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_nose/${testname}.txt"
     RESULT_FILE "${result_file}"
+    ${ARG_RUNNER}
     ${ARG_SKIP_TEST}
     ${ARG_ENV}
     ${ARG_APPEND_ENV}


### PR DESCRIPTION
Very similar to https://github.com/ament/ament_cmake/pull/174

I would like to be able execute gmock tests with a different test runner too.  (This is what rosbag2 uses, which are the tests I'm trying to isolate)

I didn't realize 'add_gmock' was another type of test that could be added in ros2.  I thought ament_add_pytest_test and ament_add_gtest took care of everything.

While I'm at it, I also took care of ament_add_nose_test too.