### PR TITLE
_library_dirs -> _library_dirs_suffix

### DIFF
--- a/ament_cmake_export_libraries/cmake/ament_export_library_names.cmake
+++ b/ament_cmake_export_libraries/cmake/ament_export_library_names.cmake
@@ -46,7 +46,7 @@ macro(ament_export_library_names)
         # keep build configuration keyword as-is
         list(APPEND _AMENT_EXPORT_LIBRARY_NAMES "${_library_name}")
       else()
-        if(_library_dirs_suffix)
+        if(_library_dirs)
           # append library directories to library name
           set(_library_name "${_library_name}:${_library_dirs}")
         endif()


### PR DESCRIPTION
This looks like a typo. `ament_export_library_names()` is a macro so the variable `_library_dirs_suffix` could come from elsewhere, but `grep` did not show any other instances in `ament_cmake`