### PR TITLE
Rename uninstall target so it is unique per project

### DIFF
--- a/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
+++ b/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
@@ -31,7 +31,7 @@ if(AMENT_CMAKE_UNINSTALL_TARGET)
     @ONLY
   )
 
-# register uninstall target to run generated CMake script
-add_custom_target(${PROJECT_NAME}_uninstall
-  COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
+  # register uninstall target to run generated CMake script
+  add_custom_target(${PROJECT_NAME}_uninstall
+    COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
 endif()

--- a/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
+++ b/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
@@ -31,7 +31,12 @@ if(AMENT_CMAKE_UNINSTALL_TARGET)
     @ONLY
   )
 
+  if (NOT TARGET uninstall)
+    add_custom_target(uninstall)
+  endif()
+
   # register uninstall target to run generated CMake script
   add_custom_target(${PROJECT_NAME}_uninstall
     COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
+  add_dependencies(uninstall ${PROJECT_NAME}_uninstall)
 endif()

--- a/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
+++ b/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
@@ -31,7 +31,7 @@ if(AMENT_CMAKE_UNINSTALL_TARGET)
     @ONLY
   )
 
-  # register uninstall target to run generated CMake script
-  add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
+# register uninstall target to run generated CMake script
+add_custom_target(${PROJECT_NAME}_uninstall
+  COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
 endif()


### PR DESCRIPTION
Fixes #127
Simpler implementation than stalled PR #128
This is needed for cleanly developing multiple projects with a CMake-based IDE like CLion.