### PR TITLE
Check existance of uninstall target before creating it

### DIFF
--- a/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
+++ b/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
@@ -35,8 +35,10 @@ if(AMENT_CMAKE_UNINSTALL_TARGET)
     add_custom_target(uninstall)
   endif()
 
-  # register uninstall target to run generated CMake script
-  add_custom_target(${PROJECT_NAME}_uninstall
-    COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
-  add_dependencies(uninstall ${PROJECT_NAME}_uninstall)
+  if (NOT TARGET ${PROJECT_NAME}_uninstall)
+    # register uninstall target to run generated CMake script
+    add_custom_target(${PROJECT_NAME}_uninstall
+      COMMAND ${CMAKE_COMMAND} -P "${AMENT_CMAKE_UNINSTALL_TARGET_UNINSTALL_SCRIPT}")
+    add_dependencies(uninstall ${PROJECT_NAME}_uninstall)
+  endif()
 endif()


### PR DESCRIPTION
If in a CMake project the `ament_cmake_uninstall_target` script is called multiple times, this results in the following error.

```
CMake Error at /home/asoragna/ros2_sdk/install/ament_cmake_core/share/ament_cmake_core/cmake/ament_cmake_uninstall_target-extras.cmake:39 (add_custom_target):
  add_custom_target cannot create target "myproject_uninstall" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory
  "/home/asoragna/repos/myproject/ros2".  See documentation for policy
  CMP0002 for more details.
```


This PR fixes it.