### PR TITLE
add CMake macro ament_bump_development_version_if_necessary

### DIFF
--- a/ament_cmake/CMakeLists.txt
+++ b/ament_cmake/CMakeLists.txt
@@ -17,6 +17,7 @@ ament_export_dependencies(
   "ament_cmake_python"
   "ament_cmake_target_dependencies"
   "ament_cmake_test"
+  "ament_cmake_version"
 )
 
 ament_package()

--- a/ament_cmake/package.xml
+++ b/ament_cmake/package.xml
@@ -25,6 +25,7 @@
   <build_export_depend>ament_cmake_python</build_export_depend>
   <build_export_depend>ament_cmake_target_dependencies</build_export_depend>
   <build_export_depend>ament_cmake_test</build_export_depend>
+  <build_export_depend>ament_cmake_version</build_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ament_cmake_version/CMakeLists.txt
+++ b/ament_cmake_version/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ament_cmake_version NONE)
+
+find_package(ament_cmake_core REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "ament_cmake_version-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/ament_cmake_version/ament_cmake_version-extras.cmake
+++ b/ament_cmake_version/ament_cmake_version-extras.cmake
@@ -18,4 +18,4 @@
 find_package(ament_cmake_core QUIET REQUIRED)
 
 include(
-  "${ament_cmake_version_DIR}/ament_bump_development_version_if_necessary.cmake")
+  "${ament_cmake_version_DIR}/ament_export_development_version_if_higher_than_manifest.cmake")

--- a/ament_cmake_version/ament_cmake_version-extras.cmake
+++ b/ament_cmake_version/ament_cmake_version-extras.cmake
@@ -1,0 +1,21 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from
+# ament_cmake_version/ament_cmake_version-extras.cmake
+
+find_package(ament_cmake_core QUIET REQUIRED)
+
+include(
+  "${ament_cmake_version_DIR}/ament_bump_development_version_if_necessary.cmake")

--- a/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
+++ b/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
@@ -48,8 +48,8 @@ macro(ament_bump_development_version_if_necessary development_version)
 
   if("${${PROJECT_NAME}_VERSION}" VERSION_LESS "${development_version}")
     message(STATUS
-      "Overriding exported package version ${${PROJECT_NAME}_VERSION} with "
-      "development version ${development_version}")
+      "Overriding exported package version '${${PROJECT_NAME}_VERSION}' with "
+      "development version '${development_version}'")
     set(${PROJECT_NAME}_VERSION "${development_version}")
   endif()
 endmacro()

--- a/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
+++ b/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
@@ -48,7 +48,7 @@ macro(ament_bump_development_version_if_necessary development_version)
 
   if("${${PROJECT_NAME}_VERSION}" VERSION_LESS "${development_version}")
     message(STATUS
-      "Override exported package version ${${PROJECT_NAME}_VERSION} with "
+      "Overriding exported package version ${${PROJECT_NAME}_VERSION} with "
       "development version ${development_version}")
     set(${PROJECT_NAME}_VERSION "${development_version}")
   endif()

--- a/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
+++ b/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
@@ -19,7 +19,7 @@
 # It is recommended to append the suffix ``-dev`` to the passed upcoming
 # version number.
 # If the package version in the manifest is equal or newer than the passed
-# development version this function call becomes a no op.
+# development version this function call becomes a no-op.
 #
 # .. note:: It is indirectly calling``ament_package_xml()`` if that hasn't
 #   happened already.

--- a/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
+++ b/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
@@ -1,0 +1,55 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Bump the exported package version to the passed version if the package
+# version in the manifest is lower.
+#
+# It is recommended to append the suffix ``-dev`` to the passed upcoming
+# version number.
+# If the package version in the manifest is equal or newer than the passed
+# development version this function call becomes a no op.
+#
+# .. note:: It is indirectly calling``ament_package_xml()`` if that hasn't
+#   happened already.
+#
+# :param target: development_version
+# :type target: string
+#
+# @public
+#
+macro(ament_bump_development_version_if_necessary development_version)
+  if(ARGN)
+    message(FATAL_ERROR
+      "ament_generate_environment() called with unused arguments: ${ARGN}")
+  endif()
+
+  if(DEFINED _${PROJECT_NAME}_AMENT_PACKAGE)
+    message(FATAL_ERROR
+      "ament_bump_development_version_if_necessary() must be called before "
+      "ament_package()")
+  endif()
+
+  # call ament_package_xml() if it has not been called before
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+
+  if("${${PROJECT_NAME}_VERSION}" VERSION_LESS "${development_version}")
+    message(STATUS
+      "Override exported package version ${${PROJECT_NAME}_VERSION} with "
+      "development version ${development_version}")
+    set(${PROJECT_NAME}_VERSION "${development_version}")
+  endif()
+endmacro()

--- a/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
+++ b/ament_cmake_version/cmake/ament_bump_development_version_if_necessary.cmake
@@ -32,7 +32,7 @@
 macro(ament_bump_development_version_if_necessary development_version)
   if(ARGN)
     message(FATAL_ERROR
-      "ament_generate_environment() called with unused arguments: ${ARGN}")
+      "ament_bump_development_version_if_necessary() called with unused arguments: ${ARGN}")
   endif()
 
   if(DEFINED _${PROJECT_NAME}_AMENT_PACKAGE)

--- a/ament_cmake_version/cmake/ament_export_development_version_if_higher_than_manifest.cmake
+++ b/ament_cmake_version/cmake/ament_export_development_version_if_higher_than_manifest.cmake
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 #
-# Bump the exported package version to the passed version if the package
+# Set the exported package version to the passed value if the package
 # version in the manifest is lower.
 #
 # It is recommended to append the suffix ``-dev`` to the passed upcoming
 # version number.
 # If the package version in the manifest is equal or newer than the passed
 # development version this function call becomes a no-op.
+# If the function is called multiple times only the higher version number will
+# be used.
 #
 # .. note:: It is indirectly calling``ament_package_xml()`` if that hasn't
 #   happened already.
@@ -29,15 +31,15 @@
 #
 # @public
 #
-macro(ament_bump_development_version_if_necessary development_version)
+macro(ament_export_development_version_if_higher_than_manifest development_version)
   if(ARGN)
     message(FATAL_ERROR
-      "ament_bump_development_version_if_necessary() called with unused arguments: ${ARGN}")
+      "ament_export_development_version_if_higher_than_manifest() called with unused arguments: ${ARGN}")
   endif()
 
   if(DEFINED _${PROJECT_NAME}_AMENT_PACKAGE)
     message(FATAL_ERROR
-      "ament_bump_development_version_if_necessary() must be called before "
+      "ament_export_development_version_if_higher_than_manifest() must be called before "
       "ament_package()")
   endif()
 

--- a/ament_cmake_version/package.xml
+++ b/ament_cmake_version/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_cmake_version</name>
+  <version>0.8.0</version>
+  <description>The ability to override the exported package version in the ament buildsystem.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Provide a standardized mechanism to override the exported package number. It can be used when a package makes breaking changes and wants to already identify itself with the upcoming version number to enable conditional logic.

The `-dev` suffix if a pure recommendation and not strictly necessary.

Regarding the naming of the macro please make concrete proposals if you would like to see a different name.

Generating a C header and providing C macros to compare version numbers is explicitly not included in this PR since it is considered syntactic sugar and not required to satisfy ros2/rmw#188.