### PR TITLE
Don't make uninstall target by default

### DIFF
--- a/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
+++ b/ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
@@ -15,7 +15,7 @@
 # copied from ament_cmake_core/ament_cmake_uninstall_target-extras.cmake
 
 option(AMENT_CMAKE_UNINSTALL_TARGET
-  "Generate an uninstall target to revert the effects of the install step" ON)
+  "Generate an uninstall target to revert the effects of the install step" OFF)
 
 if(AMENT_CMAKE_UNINSTALL_TARGET)
   include(


### PR DESCRIPTION
Generating the install target has a small but consistent hit on build times:
`/usr/bin/time -a -o log.txt colcon build --packages-up-to rmw --executor sequential > /dev/null`
result of 3 trials:
```
16.11user 2.72system 0:17.78elapsed 105%CPU (0avgtext+0avgdata 53764maxresident)k
0inputs+24064outputs (0major+1443057minor)pagefaults 0swaps
16.39user 2.89system 0:18.19elapsed 106%CPU (0avgtext+0avgdata 53908maxresident)k
0inputs+24064outputs (0major+1442767minor)pagefaults 0swaps
16.35user 2.57system 0:17.85elapsed 106%CPU (0avgtext+0avgdata 53908maxresident)k
0inputs+24064outputs (0major+1442707minor)pagefaults 0swaps
```

`/usr/bin/time -a -o log.txt colcon build --packages-up-to rmw --executor sequential --cmake-args " -DAMENT_CMAKE_UNINSTALL_TARGET=OFF"  > /dev/null`
```
15.78user 2.76system 0:17.50elapsed 105%CPU (0avgtext+0avgdata 53796maxresident)k
0inputs+23760outputs (0major+1442470minor)pagefaults 0swaps
15.96user 2.88system 0:17.77elapsed 106%CPU (0avgtext+0avgdata 53824maxresident)k
0inputs+24072outputs (0major+1442978minor)pagefaults 0swaps
15.69user 2.83system 0:17.44elapsed 106%CPU (0avgtext+0avgdata 53948maxresident)k
216inputs+24072outputs (0major+1445926minor)pagefaults 0swaps
```

Signed-off-by: Dan Rose <dan@digilabs.io>