### PR TITLE
add .dsv env hooks to the local_setup.dsv

### DIFF
--- a/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
@@ -95,6 +95,12 @@ function(ament_generate_package_environment)
   endforeach()
 
   # generate local_setup.dsv file
+  if(DEFINED _AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv)
+    list(SORT _AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv)
+    foreach(hook ${_AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv})
+      set(all_hooks "${all_hooks}source;${hook}\n")
+    endforeach()
+  endif()
   list(APPEND all_package_level_extensions "dsv")
   set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/local_setup.dsv")
   file(WRITE "${dsv_file}" "${all_hooks}")


### PR DESCRIPTION
A `dsv` env hook file added `ament_environment_hooks` which doesn't have an equivalent shell script with the same basename wasn't considered when sourcing the package / workspace.

The patch adds similar logic explicitly for `dsv` file which existing for other extensions: https://github.com/ament/ament_cmake/blob/44e9b21ef0a7fd72d5adce9cb6990b3ecb90dd49/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake#L56-L58