### PR TITLE
remove status attribute from result XML, add skipped tag instead

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -305,8 +305,8 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
         if skip else ''
     return """<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skip="%d">
-  <testcase classname="%s" name="%s.missing_result" status="%s" time="0">
-    %s%s
+  <testcase classname="%s" name="%s.missing_result" time="0">
+    %s%s%s
   </testcase>
 </testsuite>\n""" % \
         (
@@ -314,7 +314,7 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
             1 if failure_message else 0,
             1 if skip else 0,
             pkgname, testname,
-            'notrun' if skip else 'run',
+            '<skipped/>' if skip else '',
             failure_message, skipped_message
         )
 


### PR DESCRIPTION
In order to comply with the [JUnit schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd). Otherwise the Jenkins plugin (never versions / different report types) will consider the report invalid and fail the build.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9354)](http://ci.ros2.org/job/ci_linux/9354/) (some flaky tests since the build ran without retesting, others are failing on master already)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5038)](http://ci.ros2.org/job/ci_linux-aarch64/5038/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7660)](http://ci.ros2.org/job/ci_osx/7660/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9275)](http://ci.ros2.org/job/ci_windows/9275/)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=142)](http://ci.ros2.org/job/ci_windows-container/142/)