### PR TITLE
Fix handling of macro argument

### DIFF
--- a/ament_cmake_version/cmake/ament_export_development_version_if_higher_than_manifest.cmake
+++ b/ament_cmake_version/cmake/ament_export_development_version_if_higher_than_manifest.cmake
@@ -32,7 +32,7 @@
 # @public
 #
 macro(ament_export_development_version_if_higher_than_manifest development_version)
-  if(ARGN)
+  if(${ARGN})
     message(FATAL_ERROR
       "ament_export_development_version_if_higher_than_manifest() called with unused arguments: ${ARGN}")
   endif()


### PR DESCRIPTION
Macro invocations handle arguments differently than functions https://cmake.org/cmake/help/latest/command/macro.html#macro-vs-function
This can cause a false positive like:
```
-- Found rcutils: 0.8.4 (/opt/ros/master/install/share/rcutils/cmake)
CMake Error at install/share/ament_cmake_version/cmake/ament_export_development_version_if_higher_than_manifest.cmake:36 (message):
  ament_export_development_version_if_higher_than_manifest() called with
  unused arguments:
Call Stack (most recent call first):
  src/ros2/rmw/rmw/CMakeLists.txt:66 (ament_export_development_version_if_higher_than_manifest)
```

Signed-off-by: Dan Rose <dan@digilabs.io>
