### PR TITLE
Use DEPRECATION instead of WARNING for package deprecation messages

### DIFF
--- a/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
+++ b/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
@@ -26,7 +26,7 @@ if(NOT "@PACKAGE_DEPRECATED@" STREQUAL "")
   if(NOT "@PACKAGE_DEPRECATED@" STREQUAL "TRUE")
     set(_msg "${_msg} (@PACKAGE_DEPRECATED@)")
   endif()
-  message(WARNING "${_msg}")
+  message(DEPRECATION "${_msg}")
 endif()
 
 # flag package as ament-based to distinguish it after being find_package()-ed

--- a/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
+++ b/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
@@ -26,7 +26,10 @@ if(NOT "@PACKAGE_DEPRECATED@" STREQUAL "")
   if(NOT "@PACKAGE_DEPRECATED@" STREQUAL "TRUE")
     set(_msg "${_msg} (@PACKAGE_DEPRECATED@)")
   endif()
-  message(DEPRECATION "${_msg}")
+  # optionally quiet the deprecation message
+  if(NOT ${@PROJECT_NAME@_DEPRECATED_QUIET})
+    message(DEPRECATION "${_msg}")
+  endif()
 endif()
 
 # flag package as ament-based to distinguish it after being find_package()-ed


### PR DESCRIPTION
This makes it possible to treat the warnings differently in downstream packages.
Refer to the CMake documentation for more info: https://cmake.org/cmake/help/v3.0/command/message.html

Related to https://github.com/ros2/build_farmer/issues/267