### PR TITLE
Generate xunit files valid for the junit10.xsd

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -304,7 +304,7 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
         '<skipped type="skip" message="">![CDATA[Test Skipped by developer]]</skipped>' \
         if skip else ''
     return """<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skip="%d">
+<testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skipped="%d">
   <testcase classname="%s" name="%s.missing_result" time="0">
     %s%s%s
   </testcase>


### PR DESCRIPTION
Following https://github.com/ament/ament_lint/pull/220 . Same rationale, in this case just change `skip` by `skipped`