### PR TITLE
[Eloquent] Backport junit xml fixes for updated xunit plugin on ci.ros2.org

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -305,8 +305,8 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
         if skip else ''
     return """<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skip="%d">
-  <testcase classname="%s" name="%s.missing_result" status="%s" time="0">
-    %s%s
+  <testcase classname="%s" name="%s.missing_result" time="0">
+    %s%s%s
   </testcase>
 </testsuite>\n""" % \
         (
@@ -314,7 +314,7 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
             1 if failure_message else 0,
             1 if skip else 0,
             pkgname, testname,
-            'notrun' if skip else 'run',
+            '<skipped/>' if skip else '',
             failure_message, skipped_message
         )
 

--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -304,7 +304,7 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
         '<skipped type="skip" message="">![CDATA[Test Skipped by developer]]</skipped>' \
         if skip else ''
     return """<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skip="%d">
+<testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skipped="%d">
   <testcase classname="%s" name="%s.missing_result" time="0">
     %s%s%s
   </testcase>


### PR DESCRIPTION
This PR along with its companion https://github.com/ament/ament_lint/pull/222 should fix Eloquent CI builds failing during the test result parsing stage on ci.ros2.org.

Backports PRs #218 and #225.