### PR TITLE
fix names of exported interfaces in @PROJECT_NAME@_INTERFACES

### DIFF
--- a/ament_cmake_export_interfaces/cmake/ament_cmake_export_interfaces-extras.cmake.in
+++ b/ament_cmake_export_interfaces/cmake/ament_cmake_export_interfaces-extras.cmake.in
@@ -9,17 +9,16 @@ if(NOT _exported_interfaces STREQUAL "")
     include("${_export_file}")
 
     # extract the target names associated with the export
+    set(_regex "foreach\\(_expectedTarget (.+)\\)")
     file(
       STRINGS "${_export_file}" _foreach_targets
-      REGEX "foreach\\(_expectedTarget (.+)\\)")
+      REGEX "${_regex}")
     list(LENGTH _foreach_targets _matches)
     if(NOT _matches EQUAL 1)
       message(FATAL_ERROR
         "Failed to find exported target names in '${_export_file}'")
     endif()
-    string(LENGTH "${_foreach_targets}" _length)
-    math(EXPR _substring_length "${_length} - 25")
-    string(SUBSTRING "${_foreach_targets}" 24 ${_substring_length} _targets)
+    string(REGEX REPLACE "${_regex}" "\\1" _targets "${_foreach_targets}")
     string(REPLACE " " ";" _targets "${_targets}")
     list(LENGTH _targets _length)
 

--- a/ament_cmake_export_interfaces/cmake/ament_cmake_export_interfaces-extras.cmake.in
+++ b/ament_cmake_export_interfaces/cmake/ament_cmake_export_interfaces-extras.cmake.in
@@ -5,7 +5,24 @@ set(_exported_interfaces "@_AMENT_CMAKE_EXPORT_INTERFACES@")
 # include all exported interfaces
 if(NOT _exported_interfaces STREQUAL "")
   foreach(_interface ${_exported_interfaces})
-    include("${@PROJECT_NAME@_DIR}/${_interface}Export.cmake")
-    list(APPEND @PROJECT_NAME@_INTERFACES "@PROJECT_NAME@::${_interface}")
+    set(_export_file "${@PROJECT_NAME@_DIR}/${_interface}Export.cmake")
+    include("${_export_file}")
+
+    # extract the target names associated with the export
+    file(
+      STRINGS "${_export_file}" _foreach_targets
+      REGEX "foreach\\(_expectedTarget (.+)\\)")
+    list(LENGTH _foreach_targets _matches)
+    if(NOT _matches EQUAL 1)
+      message(FATAL_ERROR
+        "Failed to find exported target names in '${_export_file}'")
+    endif()
+    string(LENGTH "${_foreach_targets}" _length)
+    math(EXPR _substring_length "${_length} - 25")
+    string(SUBSTRING "${_foreach_targets}" 24 ${_substring_length} _targets)
+    string(REPLACE " " ";" _targets "${_targets}")
+    list(LENGTH _targets _length)
+
+    list(APPEND @PROJECT_NAME@_INTERFACES ${_targets})
   endforeach()
 endif()


### PR DESCRIPTION
Fixes #183.

Unfortunately I don't think there is a CMake API to get the target names for an export name. Therefore this patch parses the generated CMake export file. :disappointed:

CI builds (without retrying flaky tests):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9808)](http://ci.ros2.org/job/ci_linux/9808/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5435)](http://ci.ros2.org/job/ci_linux-aarch64/5435/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7978)](http://ci.ros2.org/job/ci_osx/7978/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9672)](http://ci.ros2.org/job/ci_windows/9672/)