### PR TITLE
use OUTPUT_NAME of exported library if set

### DIFF
--- a/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake
+++ b/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake
@@ -114,7 +114,12 @@ macro(ament_export_libraries)
           # they will be resolved via find_library()
           # relative to the CMAKE_INSTALL_PREFIX
           # when find_package() is invoked from a downstream package
-          list(APPEND _AMENT_EXPORT_LIBRARIES ${_cfg} "${_lib}")
+          get_target_property(_output_name ${_lib} OUTPUT_NAME)
+          if(_output_name)
+            list(APPEND _AMENT_EXPORT_LIBRARIES ${_cfg} "${_output_name}")
+          else()
+            list(APPEND _AMENT_EXPORT_LIBRARIES ${_cfg} "${_lib}")
+          endif()
         endif()
       else()
         # keep plain library names as-is


### PR DESCRIPTION
Required for ros2/rmw_dds_common#12.