### PR TITLE
Report skipped tests in CTest output

### DIFF
--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -124,4 +124,10 @@ function(ament_add_test testname)
     "${testname}"
     PROPERTIES TIMEOUT ${ARG_TIMEOUT}
   )
+  if(ARG_SKIP_TEST)
+    set_tests_properties(
+      "${testname}"
+      PROPERTIES SKIP_RETURN_CODE 0
+    )
+  endif()
 endfunction()


### PR DESCRIPTION
When adding a test using `ament_add_test`, the `SKIP_TEST` argument results in the `--skip-test` argument being passed to the test wrapper script `run_test.py`. The wrapper script then writes a JUnit output describing that the test was skipped, and returns 0.

As far as CTest knows, the test succeeded and shows `Passed` on the console. However, since we know that the test will be skipped by the wrapper, and we expect the wrapper to return 0 after it writes the JUnit file, we can set a test property that will mark the test as `Skipped` when the wrapper returns 0.

This way, the JUnit output file is still written, but CTest displays the test as skipped as well.

The `SKIP_RETURN_CODE` test property is [present in CMake 3.0.2](https://cmake.org/cmake/help/v3.0/manual/cmake-properties.7.html#properties-on-tests), if not earlier.