### PR TITLE
Use errors attribute for problems when testing code (take II)

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -103,7 +103,7 @@ def main(argv=sys.argv[1:]):
     # in case the command segfaults or timeouts and does not generate one
     failure_result_file = _generate_result(
         args.result_file,
-        failure_message='The test did not generate a result file.')
+        error_message='The test did not generate a result file.')
     with open(args.result_file, 'w') as h:
         h.write(failure_result_file)
 
@@ -237,7 +237,7 @@ def _run_test(parser, args, failure_result_file, output_handle):
             # regenerate result file to include output / exception of the invoked command
             failure_result_file = _generate_result(
                 args.result_file,
-                failure_message='The test did not generate a result file:\n\n' + output)
+                error_message='The test did not generate a result file:\n\n' + output)
             with open(args.result_file, 'w') as h:
                 h.write(failure_result_file)
         else:
@@ -293,7 +293,7 @@ def _run_test(parser, args, failure_result_file, output_handle):
     return rc
 
 
-def _generate_result(result_file, *, failure_message=None, skip=False):
+def _generate_result(result_file, *, failure_message=None, skip=False, error_message=None):
     # the generated result file must be readable
     # by any of the Jenkins test result report publishers
     pkgname = os.path.basename(os.path.dirname(result_file))
@@ -304,17 +304,18 @@ def _generate_result(result_file, *, failure_message=None, skip=False):
         '<skipped type="skip" message="">![CDATA[Test Skipped by developer]]</skipped>' \
         if skip else ''
     return """<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="%s" tests="1" failures="%d" time="0" errors="0" skipped="%d">
+<testsuite name="%s" tests="1" failures="%d" time="0" errors="%d" skipped="%d">
   <testcase classname="%s" name="%s.missing_result" time="0">
-    %s%s
+    %s%s%s
   </testcase>
 </testsuite>\n""" % \
         (
             pkgname,
             1 if failure_message else 0,
+            1 if error_message else 0,
             1 if skip else 0,
             pkgname, testname,
-            failure_message, skipped_message
+            failure_message, skipped_message, error_message
         )
 
 

--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -298,6 +298,8 @@ def _generate_result(result_file, *, failure_message=None, skip=False, error_mes
     # by any of the Jenkins test result report publishers
     pkgname = os.path.basename(os.path.dirname(result_file))
     testname = os.path.splitext(os.path.basename(result_file))[0]
+    error_message = '<error message=%s/>' % quoteattr(error_message) \
+        if error_message else ''
     failure_message = '<failure message=%s/>' % quoteattr(failure_message) \
         if failure_message else ''
     skipped_message = \


### PR DESCRIPTION
Following discussion in #225 (comment), the PR changes the use of failures attribute to errors to report problems with testing code (note the difference with the usual failing tests).

rework of #228

Testing using packages up to rclcpp [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10520)](https://ci.ros2.org/job/ci_linux/10520/)