### PR TITLE
Fix parallel testing

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -113,7 +113,7 @@ def main(argv=sys.argv[1:]):
     if args.output_file:
         output_path = os.path.dirname(args.output_file)
         if not os.path.exists(output_path):
-            os.makedirs(output_path)
+            os.makedirs(output_path, exist_ok=True)
         output_handle = open(args.output_file, 'wb')
 
     try:

--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -112,8 +112,7 @@ def main(argv=sys.argv[1:]):
     output_handle = None
     if args.output_file:
         output_path = os.path.dirname(args.output_file)
-        if not os.path.exists(output_path):
-            os.makedirs(output_path, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
         output_handle = open(args.output_file, 'wb')
 
     try:


### PR DESCRIPTION
We ran ctest . -j 10, and sometimes it happened that we got failing CI builds because the command in line 116 was executed in parallel.
```
[2020-04-28T19:13:39.193Z] 1: Traceback (most recent call last):
[2020-04-28T19:13:39.193Z] 1:   File "/opt/ros/eloquent/share/ament_cmake_test/cmake/run_test.py", line 23, in <module>
[2020-04-28T19:13:39.193Z] 1:     sys.exit(ament_cmake_test.main())
[2020-04-28T19:13:39.193Z] 1:   File "/opt/ros/eloquent/lib/python3.6/site-packages/ament_cmake_test/__init__.py", line 116, in main
[2020-04-28T19:13:39.193Z] 1:     os.makedirs(output_path)
[2020-04-28T19:13:39.193Z] 1:   File "/usr/lib/python3.6/os.py", line 220, in makedirs
[2020-04-28T19:13:39.193Z] 1:     mkdir(name, mode)
[2020-04-28T19:13:39.193Z] 1: FileExistsError: [Errno 17] File exists: 'some_dir/build/x86_debug/ros2/build_docker/functions/ament_cmake_gtest'
```