### PR TITLE
Initial ament_cmake_google_benchmark package

### DIFF
--- a/ament_cmake_google_benchmark/CMakeLists.txt
+++ b/ament_cmake_google_benchmark/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+project(ament_cmake_google_benchmark NONE)
+
+# find dependencies
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+
+ament_package(
+  CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark-extras.cmake
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark-extras.cmake
@@ -1,0 +1,34 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+macro(_ament_cmake_google_benchmark_find_benchmark)
+  if(NOT DEFINED _AMENT_CMAKE_GOOGLE_BENCHMARK_FIND_BENCHMARK)
+    set(_AMENT_CMAKE_GOOGLE_BENCHMARK_FIND_BENCHMARK TRUE)
+
+    find_package(benchmark QUIET)
+
+    if(NOT benchmark_FOUND)
+      message(WARNING
+        "'benchmark' not found, C++ tests using 'Google Benchmark' can not be "
+        "built. Please install the 'Google Benchmark' headers globally in "
+        "your system to enable these tests (e.g. on Ubuntu/Debian install the "
+        "package 'libbenchmark-dev') or get the ament package "
+        "'google_benchmark_vendor'")
+    endif()
+  endif()
+endmacro()
+
+include("${ament_cmake_google_benchmark_DIR}/ament_add_google_benchmark.cmake")
+include("${ament_cmake_google_benchmark_DIR}/ament_add_google_benchmark_executable.cmake")
+include("${ament_cmake_google_benchmark_DIR}/ament_add_google_benchmark_test.cmake")

--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import os
 import subprocess
 import sys
 
@@ -38,6 +39,11 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
     args.command = command
 
+    if os.environ.get('AMENT_RUN_PERFORMANCE_TESTS') not in (
+        '1', 'true', 'True', 'TRUE', 'yes', 'Yes', 'YES', 'y', 'Y'
+    ):
+        return 127
+
     res = subprocess.run(args.command)
 
     with open(args.result_file_in, 'r') as in_file:
@@ -45,4 +51,4 @@ def main(argv=sys.argv[1:]):
             # TODO(cottsay): Convert the results file
             pass
 
-    return res.returncode
+    return res.returncode if res.returncode != 127 else 1

--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import subprocess
+import sys
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Run a Google Benchmark test and convert the results to '
+                    'a common format.')
+    parser.add_argument(
+        'result_file_in', help='The path to the Google Benchmark result file')
+    parser.add_argument(
+        'result_file_out',
+        help='The path to where the common result file should be written')
+    parser.add_argument(
+        '--command',
+        nargs='+',
+        help='The test command to execute. '
+             'It must be passed after other arguments since it collects all '
+             'following options.')
+    if '--command' in argv:
+        index = argv.index('--command')
+        argv, command = argv[0:index + 1] + ['dummy'], argv[index + 1:]
+    args = parser.parse_args(argv)
+    args.command = command
+
+    res = subprocess.run(args.command)
+
+    with open(args.result_file_in, 'r') as in_file:
+        with open(args.result_file_out, 'w') as out_file:
+            # TODO(cottsay): Convert the results file
+            pass
+
+    return res.returncode

--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import argparse
-import os
 import subprocess
 import sys
 
@@ -39,11 +38,6 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
     args.command = command
 
-    if os.environ.get('AMENT_RUN_PERFORMANCE_TESTS') not in (
-        '1', 'true', 'True', 'TRUE', 'yes', 'Yes', 'YES', 'y', 'Y'
-    ):
-        return 127
-
     res = subprocess.run(args.command)
 
     with open(args.result_file_in, 'r') as in_file:
@@ -51,4 +45,4 @@ def main(argv=sys.argv[1:]):
             # TODO(cottsay): Convert the results file
             pass
 
-    return res.returncode if res.returncode != 127 else 1
+    return res.returncode

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark.cmake
@@ -1,0 +1,96 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a google benchmark test.
+#
+# Call add_executable(target ARGN), link it against the google benchmark
+# libraries and register the executable as a test.
+#
+# If google benchmark is not available the specified target is not being created
+# and therefore the target existence should be checked before being used.
+#
+# :param target: the target name which will also be used as the test name
+# :type target: string
+# :param ARGN: the list of source files
+# :type ARGN: list of strings
+# :param RUNNER: the path to the test runner script (default: see
+#   ament_add_test).
+# :type RUNNER: string
+# :param TIMEOUT: the test timeout in seconds,
+#   default defined by ``ament_add_test()``
+# :type TIMEOUT: integer
+# :param WORKING_DIRECTORY: the working directory for invoking the
+#   executable in, default defined by ``ament_add_test()``
+# :type WORKING_DIRECTORY: string
+# :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the google
+#   benchmark main libraries
+# :type SKIP_LINKING_MAIN_LIBRARIES: option
+# :param SKIP_TEST: if set mark the test as being skipped
+# :type SKIP_TEST: option
+# :param ENV: list of env vars to set; listed as ``VAR=value``
+# :type ENV: list of strings
+# :param APPEND_ENV: list of env vars to append if already set, otherwise set;
+#   listed as ``VAR=value``
+# :type APPEND_ENV: list of strings
+# :param APPEND_LIBRARY_DIRS: list of library dirs to append to the appropriate
+#   OS specific env var, a la LD_LIBRARY_PATH
+# :type APPEND_LIBRARY_DIRS: list of strings
+#
+# @public
+#
+macro(ament_add_google_benchmark target)
+  cmake_parse_arguments(_ARG
+    "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
+    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
+    ${ARGN})
+  if(NOT _ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ament_add_google_benchmark() must be invoked with at least one "
+      "source file")
+  endif()
+
+  # add executable
+  set(_argn_executable ${_ARG_UNPARSED_ARGUMENTS})
+  if(_ARG_SKIP_LINKING_MAIN_LIBRARIES)
+    list(APPEND _argn_executable "SKIP_LINKING_MAIN_LIBRARIES")
+  endif()
+  ament_add_google_benchmark_executable("${target}" ${_argn_executable})
+
+  # add test
+  set(_argn_test "")
+  if(_ARG_RUNNER)
+    list(APPEND _argn_test "RUNNER" "${_ARG_RUNNER}")
+  endif()
+  if(_ARG_TIMEOUT)
+    list(APPEND _argn_test "TIMEOUT" "${_ARG_TIMEOUT}")
+  endif()
+  if(_ARG_WORKING_DIRECTORY)
+    list(APPEND _argn_test "WORKING_DIRECTORY" "${_ARG_WORKING_DIRECTORY}")
+  endif()
+  if(_ARG_SKIP_TEST)
+    list(APPEND _argn_test "SKIP_TEST")
+  endif()
+  if(_ARG_ENV)
+    list(APPEND _argn_test "ENV" ${_ARG_ENV})
+  endif()
+  if(_ARG_APPEND_ENV)
+    list(APPEND _argn_test "APPEND_ENV" ${_ARG_APPEND_ENV})
+  endif()
+  if(_ARG_APPEND_LIBRARY_DIRS)
+    list(APPEND _argn_test "APPEND_LIBRARY_DIRS" ${_ARG_APPEND_LIBRARY_DIRS})
+  endif()
+  ament_add_google_benchmark_test("${target}" ${_argn_test})
+endmacro()

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_executable.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_executable.cmake
@@ -1,0 +1,57 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add an executable using google benchmark.
+#
+# Call add_executable(target ARGN) and link it against the google benchmark
+# libraries.
+# It does not register the executable as a test.
+#
+# If google benchmark is not available the specified target is not being created
+# and therefore the target existence should be checked before being used.
+#
+# :param target: the target name which will also be used as the test name
+# :type target: string
+# :param ARGN: the list of source files
+# :type ARGN: list of strings
+# :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the google
+#   benchmark main libraries
+# :type SKIP_LINKING_MAIN_LIBRARIES: option
+#
+# @public
+#
+macro(ament_add_google_benchmark_executable target)
+  _ament_cmake_google_benchmark_find_benchmark()
+  if(benchmark_FOUND)
+    _ament_add_google_benchmark_executable("${target}" ${ARGN})
+  endif()
+endmacro()
+
+function(_ament_add_google_benchmark_executable target)
+  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "" "" ${ARGN})
+  if(NOT ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ament_add_google_benchmark_executable() must be invoked with at least "
+      "one source file")
+  endif()
+
+  # should be EXCLUDE_FROM_ALL if it would be possible
+  # to add this target as a dependency to the "test" target
+  add_executable("${target}" ${ARG_UNPARSED_ARGUMENTS})
+  if(NOT ARG_SKIP_LINKING_MAIN_LIBRARIES)
+    target_link_libraries("${target}" benchmark::benchmark_main)
+  endif()
+  target_link_libraries("${target}" benchmark::benchmark)
+endfunction()

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -93,6 +93,7 @@ function(ament_add_google_benchmark_test target)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_google_benchmark/${target}.txt"
     GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    SKIP_RETURN_CODE 127
     ${ARG_SKIP_TEST}
     ${ARG_ENV}
     ${ARG_APPEND_ENV}
@@ -104,6 +105,6 @@ function(ament_add_google_benchmark_test target)
     "${target}"
     PROPERTIES
     REQUIRED_FILES "${executable}"
-    LABELS "performance"
+    LABELS "google_benchmark;performance"
   )
 endfunction()

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -1,0 +1,109 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add an existing executable using google benchmark as a test.
+#
+# Register an executable created with ament_add_google_benchmark_executable() as
+# a test.
+# If the specified target does not exist the registration is skipped.
+#
+# :param target: the target name which will also be used as the test name
+# :type target: string
+# :param RUNNER: the path to the test runner script (default: see
+#   ament_add_test).
+# :type RUNNER: string
+# :param TIMEOUT: the test timeout in seconds,
+#   default defined by ``ament_add_test()``
+# :type TIMEOUT: integer
+# :param WORKING_DIRECTORY: the working directory for invoking the
+#   executable in, default defined by ``ament_add_test()``
+# :type WORKING_DIRECTORY: string
+# :param SKIP_TEST: if set mark the test as being skipped
+# :type SKIP_TEST: option
+# :param ENV: list of env vars to set; listed as ``VAR=value``
+# :type ENV: list of strings
+# :param APPEND_ENV: list of env vars to append if already set, otherwise set;
+#   listed as ``VAR=value``
+# :type APPEND_ENV: list of strings
+# :param APPEND_LIBRARY_DIRS: list of library dirs to append to the appropriate
+#   OS specific env var, a la LD_LIBRARY_PATH
+# :type APPEND_LIBRARY_DIRS: list of strings
+#
+# @public
+#
+function(ament_add_google_benchmark_test target)
+  if(NOT TARGET ${target})
+    return()
+  endif()
+
+  cmake_parse_arguments(ARG
+    "SKIP_TEST"
+    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
+    ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ament_add_google_benchmark_test() called with unused arguments: ${ARGN}")
+  endif()
+
+  set(executable "$<TARGET_FILE:${target}>")
+  set(benchmark_out "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${target}.google_benchmark.json")
+  set(common_out "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${target}.benchmark.json")
+  set(cmd
+    "${PYTHON_EXECUTABLE}" "-u" "${ament_cmake_google_benchmark_DIR}/run_and_convert.py"
+    "${benchmark_out}" "${common_out}" "--command"
+    "${executable}"
+    "--benchmark_out_format=json" "--benchmark_out=${benchmark_out}")
+  if(ARG_ENV)
+    set(ARG_ENV "ENV" ${ARG_ENV})
+  endif()
+  if(ARG_APPEND_ENV)
+    set(ARG_APPEND_ENV "APPEND_ENV" ${ARG_APPEND_ENV})
+  endif()
+  if(ARG_APPEND_LIBRARY_DIRS)
+    set(ARG_APPEND_LIBRARY_DIRS "APPEND_LIBRARY_DIRS" ${ARG_APPEND_LIBRARY_DIRS})
+  endif()
+  if(ARG_RUNNER)
+    set(ARG_RUNNER "RUNNER" ${ARG_RUNNER})
+  endif()
+  if(ARG_TIMEOUT)
+    set(ARG_TIMEOUT "TIMEOUT" ${ARG_TIMEOUT})
+  endif()
+  if(ARG_WORKING_DIRECTORY)
+    set(ARG_WORKING_DIRECTORY "WORKING_DIRECTORY" "${ARG_WORKING_DIRECTORY}")
+  endif()
+  if(ARG_SKIP_TEST)
+    set(ARG_SKIP_TEST "SKIP_TEST")
+  endif()
+
+  ament_add_test(
+    "${target}"
+    COMMAND ${cmd}
+    OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_google_benchmark/${target}.txt"
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    ${ARG_SKIP_TEST}
+    ${ARG_ENV}
+    ${ARG_APPEND_ENV}
+    ${ARG_APPEND_LIBRARY_DIRS}
+    ${ARG_TIMEOUT}
+    ${ARG_WORKING_DIRECTORY}
+  )
+  set_tests_properties(
+    "${target}"
+    PROPERTIES
+    REQUIRED_FILES "${executable}"
+    LABELS "performance"
+  )
+endfunction()

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -93,7 +93,6 @@ function(ament_add_google_benchmark_test target)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_google_benchmark/${target}.txt"
     GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-    SKIP_RETURN_CODE 127
     ${ARG_SKIP_TEST}
     ${ARG_ENV}
     ${ARG_APPEND_ENV}

--- a/ament_cmake_google_benchmark/cmake/run_and_convert.py
+++ b/ament_cmake_google_benchmark/cmake/run_and_convert.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import ament_cmake_google_benchmark
+
+
+if __name__ == '__main__':
+    sys.exit(ament_cmake_google_benchmark.main())

--- a/ament_cmake_google_benchmark/package.xml
+++ b/ament_cmake_google_benchmark/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_cmake_google_benchmark</name>
+  <version>0.9.6</version>
+  <description>The ability to add Google Benchmark tests in the ament buildsystem in CMake.</description>
+  <maintainer email="scott@openrobotics.org">Scott K Logan</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <exec_depend>ament_cmake_test</exec_depend>
+  <exec_depend>google_benchmark_vendor</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Requires ament/google_benchmark_vendor#1

I left the result schema conversion part of the wrapper marked with a `TODO` for now, but I'd like to make this package available right away to unblock other folks to start writing tests.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11453)](http://ci.ros2.org/job/ci_linux/11453/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6667)](http://ci.ros2.org/job/ci_linux-aarch64/6667/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9394)](http://ci.ros2.org/job/ci_osx/9394/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11354)](http://ci.ros2.org/job/ci_windows/11354/)