### PR TITLE
Add SKIP_RETURN_CODE argument to ament_add_test

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -35,6 +35,14 @@ def separate_env_vars(env_str, env_argument_name, parser):
     return key, value
 
 
+def return_code(value):
+    value = int(value)
+    if value < 0 or value > 255:
+        raise argparse.ArgumentTypeError(
+            'Return code must be less than 256 and greater or equal to 0')
+    return value
+
+
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Run the test command passed as an argument and ensures'
@@ -74,7 +82,7 @@ def main(argv=sys.argv[1:]):
         help='Skip the test')
     parser.add_argument(
         '--skip-return-code',
-        type=int,
+        type=return_code,
         help="If the test returns this value and doesn't generate a result file, "
              'create one stating that the test was skipped.')
 

--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -46,13 +46,16 @@
 # :param APPEND_LIBRARY_DIRS: list of library dirs to append to the appropriate
 #   OS specific env var, a la LD_LIBRARY_PATH
 # :type APPEND_LIBRARY_DIRS: list of strings
+# :param SKIP_RETURN_CODE: return code signifying that the test has been
+#   skipped and did not fail OR succeed
+# :type SKIP_RETURN_CODE: integer
 #
 # @public
 #
 function(ament_add_test testname)
   cmake_parse_arguments(ARG
     "GENERATE_RESULT_FOR_RETURN_CODE_ZERO;SKIP_TEST"
-    "OUTPUT_FILE;RESULT_FILE;RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "OUTPUT_FILE;RESULT_FILE;RUNNER;SKIP_RETURN_CODE;TIMEOUT;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;COMMAND;ENV"
     ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
@@ -86,6 +89,9 @@ function(ament_add_test testname)
     "--package-name" "${PROJECT_NAME}")
   if(ARG_SKIP_TEST)
     list(APPEND cmd_wrapper "--skip-test")
+    set(ARG_SKIP_RETURN_CODE 0)
+  elseif(ARG_SKIP_RETURN_CODE)
+    list(APPEND cmd_wrapper "--skip-return-code" "${ARG_SKIP_RETURN_CODE}")
   endif()
   if(ARG_GENERATE_RESULT_FOR_RETURN_CODE_ZERO)
     list(APPEND cmd_wrapper "--generate-result-on-success")
@@ -124,10 +130,10 @@ function(ament_add_test testname)
     "${testname}"
     PROPERTIES TIMEOUT ${ARG_TIMEOUT}
   )
-  if(ARG_SKIP_TEST)
+  if(ARG_SKIP_RETURN_CODE)
     set_tests_properties(
       "${testname}"
-      PROPERTIES SKIP_RETURN_CODE 0
+      PROPERTIES SKIP_RETURN_CODE ${ARG_SKIP_RETURN_CODE}
     )
   endif()
 endfunction()


### PR DESCRIPTION
This makes the `run_test.py` wrapper aware of the `SKIP_RETURN_CODE` property on CTest tests. In the existing implementation, the wrapper detects that no result file was generated and overrides the special return code coming from the test, making the the CTest feature fail completely.

This change makes the wrapper script aware of the special return code, and when detected, will write a 'skipped' result file instead of a 'failed' result file, and pass along the special return code as-is. Now the gtest result and the ctest results both show the test as 'skipped' when the special return flag is used.

Note that none of this behavior is enabled by default, which is important because we wouldn't want a test to fail and return a code which we've decided is the special 'skip' return code. Only tests which are aware of this feature should use it.

