### PR TITLE
[backport foxy] ensure gtest to consume the correct headers.

### DIFF
--- a/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
+++ b/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
@@ -87,6 +87,8 @@ macro(_ament_cmake_gtest_find_gtest)
         # mark gtest targets with EXCLUDE_FROM_ALL to only build
         # when tests are built which depend on them
         set_target_properties(gtest gtest_main PROPERTIES EXCLUDE_FROM_ALL 1)
+        target_include_directories(gtest BEFORE PUBLIC "${GTEST_FROM_SOURCE_INCLUDE_DIRS}")
+        target_include_directories(gtest_main BEFORE PUBLIC "${GTEST_FROM_SOURCE_INCLUDE_DIRS}")
       endif()
 
       # set the same variables as find_package()

--- a/ament_cmake_gtest/cmake/ament_add_gtest_executable.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest_executable.cmake
@@ -48,7 +48,7 @@ function(_ament_add_gtest_executable target)
   # should be EXCLUDE_FROM_ALL if it would be possible
   # to add this target as a dependency to the "test" target
   add_executable("${target}" ${ARG_UNPARSED_ARGUMENTS})
-  target_include_directories("${target}" PUBLIC "${GTEST_INCLUDE_DIRS}")
+  target_include_directories("${target}" BEFORE PUBLIC "${GTEST_INCLUDE_DIRS}")
   if(NOT ARG_SKIP_LINKING_MAIN_LIBRARIES)
     target_link_libraries("${target}" ${GTEST_MAIN_LIBRARIES})
   endif()


### PR DESCRIPTION
Backport of #267.