### PR TITLE
limit test time to three decimals

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -329,8 +329,8 @@ def _generate_result(result_file, *, failure_message=None, skip=False, error_mes
         '<skipped type="skip" message="">![CDATA[Test Skipped by developer]]</skipped>' \
         if skip else ''
     return """<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="%s" tests="1" failures="%d" time="%f" errors="%d" skipped="%d">
-  <testcase classname="%s" name="%s.missing_result" time="%f">
+<testsuite name="%s" tests="1" failures="%d" time="%.3f" errors="%d" skipped="%d">
+  <testcase classname="%s" name="%s.missing_result" time="%.3f">
     %s%s%s
   </testcase>
 </testsuite>\n""" % \


### PR DESCRIPTION
Fixes regression introduced by #270.

See https://issues.jenkins-ci.org/browse/JENKINS-52152 that the Jenkins xUnit plugin only considers up to 3 decimals valid.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11848)](https://ci.ros2.org/job/ci_windows/11848/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11851)](https://ci.ros2.org/job/ci_windows/11851/)