### PR TITLE
Initial Google Benchmark results conversion

### DIFF
--- a/ament_cmake_google_benchmark/README.md
+++ b/ament_cmake_google_benchmark/README.md
@@ -1,0 +1,69 @@
+# ament\_cmake\_google\_benchmark
+
+This package contains logic for invoking [Google Benchmark](https://github.com/google/benchmark#readme) tests and is
+comprised of three main parts:
+
+1. The `ament_add_google_benchmark*` CMake macros.\
+   These macros are used in ament packages to compile Google Benchmark executables, run Google Benchmark tests with
+   CTest, or both.
+2. The `run_and_convert.py` test wrapper.\
+   This script is used to convert the Google Benchmark JSON results to a custom format which can be consumed by the
+   [Jenkins Benchmark plugin](https://plugins.jenkins.io/benchmark/). The script also combines the generated results
+   with elements from an overlay file, which may contain additional context for the benchmarks, such as descriptions
+   or value thresholds.
+3. The `benchmark_schema.json` output schema.\
+   This schema describes the output format for the `run_and_convert.py` test wrapper, and should be used by Jenkins
+   in parsing the results for aggregation and threshold checks. It is also the schema used by the overlay file.
+
+### Examples
+
+The source file format is well-described in the Google Benchmark README. Here is a simple example:
+```c++
+#include <benchmark/benchmark.h>
+
+static void increment_perf(benchmark::State & state)
+{
+  size_t i = 0;
+  for (auto _ : state) {
+    i++;
+  }
+}
+BENCHMARK(increment_perf);
+```
+
+To compile and run this benchmark, the following is added to the `CMakeLists.txt`:
+```cmake
+if(BUILD_TESTING)
+  find_package(ament_cmake_google_benchmark REQUIRED)
+  ament_add_google_benchmark(simple_benchmark test/simple_benchmark.cpp)
+endif()
+```
+
+Jenkins can also trigger a build warning when the metrics exceed predefined thresholds. Here is an example overlay
+file to sets a threshold of 0.6% deviation above or below the average metric from all previous Jenkins job builds which
+include that metric:
+```json
+{
+  "package_name.simple_benchmark": {
+    "increment_perf": {
+      "real_time": {
+        "thresholds": [
+          {
+            "method": "percentageaverage",
+            "percentage": 0.6
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+This overlay file can be generated at build time or checked in as a static file. The location of the file is
+communicated to this package using the `AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY` CMake variable. For example:
+```cmake
+if(BUILD_TESTING)
+  set(AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY test/benchmark_thresholds.json)
+  ...
+endif()
+```

--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
@@ -13,8 +13,24 @@
 # limitations under the License.
 
 import argparse
+import json
+import os
 import subprocess
 import sys
+
+
+extra_metric_exclusions = {
+  'name',
+  'run_name',
+  'run_type',
+  'repetitions',
+  'repetition_index',
+  'threads',
+  'iterations',
+  'real_time',
+  'cpu_time',
+  'time_unit',
+  }
 
 
 def main(argv=sys.argv[1:]):
@@ -27,11 +43,22 @@ def main(argv=sys.argv[1:]):
         'result_file_out',
         help='The path to where the common result file should be written')
     parser.add_argument(
+        '--package-name',
+        default=None,
+        help="The package name to be used as a prefix for the 'group' "
+             'value in benchmark result files')
+    parser.add_argument(
         '--command',
         nargs='+',
         help='The test command to execute. '
              'It must be passed after other arguments since it collects all '
              'following options.')
+    parser.add_argument(
+        '--result-file-overlay',
+        default=None,
+        help='If specified, this json file will be overlaid on top of the '
+             'generated results. This is primarily useful for specifying '
+             'descriptions and/or thresholds.')
     if '--command' in argv:
         index = argv.index('--command')
         argv, command = argv[0:index + 1] + ['dummy'], argv[index + 1:]
@@ -43,8 +70,8 @@ def main(argv=sys.argv[1:]):
     try:
         with open(args.result_file_in, 'r') as in_file:
             with open(args.result_file_out, 'w') as out_file:
-                # TODO(cottsay): Convert the results file
-                pass
+                convert_google_benchark_to_jenkins_benchmark(
+                    in_file, out_file, args.package_name, args.result_file_overlay)
     except FileNotFoundError:
         if res.returncode == 0:
             print(
@@ -53,3 +80,61 @@ def main(argv=sys.argv[1:]):
             res.returncode = 1
 
     return res.returncode
+
+
+def convert_google_benchark_to_jenkins_benchmark(
+    in_file,
+    out_file,
+    package_name=None,
+    overlay_path=None
+):
+    in_data = json.load(in_file)
+    group_name = os.path.basename(in_data['context']['executable'])
+    if package_name:
+        group_name = '%s.%s' % (package_name, group_name)
+
+    out_data = {
+        group_name: {},
+    }
+    for benchmark in in_data.get('benchmarks', []):
+        out_data[group_name][benchmark['name']] = {
+            'parameters': {
+                'iterations': {
+                    'value': benchmark['iterations'],
+                },
+            },
+            'cpu_time': {
+                'dblValue': benchmark['cpu_time'],
+                'unit': benchmark['time_unit'],
+            },
+            'real_time': {
+                'dblValue': benchmark['real_time'],
+                'unit': benchmark['time_unit'],
+            },
+        }
+
+        # Add any "additional" metrics besides cpu_time and real_time
+        out_data[group_name][benchmark['name']].update({
+            extra_name: {
+                'value': benchmark[extra_name],
+            } for extra_name in set(benchmark.keys()) - extra_metric_exclusions})
+
+    if not out_data[group_name]:
+        print(
+            'WARNING: The perfromance test results file contained no results',
+            file=sys.stderr)
+
+    if overlay_path:
+        with open(overlay_path, 'r') as overlay_file:
+            overlay_data = json.load(overlay_file)
+        _merge_results(out_data[group_name], overlay_data.get(group_name, {}))
+
+    json.dump(out_data, out_file, indent=2)
+
+
+def _merge_results(target, overlay):
+    for k, v in overlay.items():
+        if isinstance(v, dict) and isinstance(target.get(k), dict):
+            merge_results(target[k], v)
+        else:
+            target[k] = v

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -60,6 +60,7 @@ function(ament_add_google_benchmark_test target)
 
   if(AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY AND NOT IS_ABSOLUTE ${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY})
     get_filename_component(AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY ${CMAKE_CURRENT_SOURCE_DIR}/${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY} ABSOLUTE)
+    set(OVERLAY_ARG "--result-file-overlay" "${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY}")
   endif()
 
   set(executable "$<TARGET_FILE:${target}>")
@@ -68,7 +69,7 @@ function(ament_add_google_benchmark_test target)
   set(cmd
     "${PYTHON_EXECUTABLE}" "-u" "${ament_cmake_google_benchmark_DIR}/run_and_convert.py"
     "${benchmark_out}" "${common_out}" "--package-name" "${PROJECT_NAME}"
-    "--result-file-overlay" "${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY}"
+    ${OVERLAY_ARG}
     "--command" "${executable}"
     "--benchmark_out_format=json" "--benchmark_out=${benchmark_out}")
   if(ARG_ENV)

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -58,13 +58,18 @@ function(ament_add_google_benchmark_test target)
       "ament_add_google_benchmark_test() called with unused arguments: ${ARGN}")
   endif()
 
+  if(AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY AND NOT IS_ABSOLUTE ${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY})
+    get_filename_component(AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY ${CMAKE_CURRENT_SOURCE_DIR}/${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY} ABSOLUTE)
+  endif()
+
   set(executable "$<TARGET_FILE:${target}>")
   set(benchmark_out "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${target}.google_benchmark.json")
   set(common_out "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${target}.benchmark.json")
   set(cmd
     "${PYTHON_EXECUTABLE}" "-u" "${ament_cmake_google_benchmark_DIR}/run_and_convert.py"
-    "${benchmark_out}" "${common_out}" "--command"
-    "${executable}"
+    "${benchmark_out}" "${common_out}" "--package-name" "${PROJECT_NAME}"
+    "--result-file-overlay" "${AMENT_CMAKE_GOOGLE_BENCHMARK_OVERLAY}"
+    "--command" "${executable}"
     "--benchmark_out_format=json" "--benchmark_out=${benchmark_out}")
   if(ARG_ENV)
     set(ARG_ENV "ENV" ${ARG_ENV})

--- a/ament_cmake_google_benchmark/doc/benchmark_schema.json
+++ b/ament_cmake_google_benchmark/doc/benchmark_schema.json
@@ -1,0 +1,137 @@
+{
+  "description": "Jenkins Benchmark schema for ROS performance test results",
+  "failure": {
+    "value": true
+  },
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "description": {
+        "type": "description"
+      },
+      "parameters": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "parameter",
+          "properties": {
+            "description": {
+              "type": "description"
+            },
+            "unit": {
+              "type": "unit"
+            },
+            "value": {
+              "type": "value"
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "description"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "parameter",
+            "properties": {
+              "description": {
+                "type": "description"
+              },
+              "unit": {
+                "type": "unit"
+              },
+              "value": {
+                "type": "value"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": {
+        "type": "result",
+        "properties": {
+          "description": {
+            "type": "description"
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "parameter",
+              "properties": {
+                "description": {
+                  "type": "description"
+                },
+                "unit": {
+                  "type": "unit"
+                },
+                "value": {
+                  "type": "value"
+                }
+              },
+              "required": [
+                "value"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "boolValue": {
+            "type": "boolean"
+          },
+          "dblValue": {
+            "type": "double"
+          },
+          "intValue": {
+            "type": "integer"
+          },
+          "unit": {
+            "type": "unit"
+          },
+          "value": {
+            "type": "value"
+          },
+          "thresholds": {
+            "type": "array",
+            "items": {
+              "type": "threshold",
+              "properties": {
+                "delta": {
+                  "type": "delta"
+                },
+                "method": {
+                  "type": "method"
+                },
+                "maximum": {
+                  "type": "maximum"
+                },
+                "minimum": {
+                  "type": "minimum"
+                },
+                "percentage": {
+                  "type": "percentage"
+                }
+              },
+              "required": [
+                "method"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change connects the Google Benchmark tests to the Jenkins Benchmark plugin to display the results and warn developers when thresholds are exceeded.

Here is a temporary job demonstrating this functionality for review purposes: http://build.ros2.org/view/Rci/job/Rci__benchmark_ubuntu_focal_amd64/BenchmarkTable/