### PR TITLE
Handle Google Benchmark 'aggregate' results

### DIFF
--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark/__init__.py
@@ -178,9 +178,9 @@ def convert_iteration_benchmark(in_data):
     return out_data
 
 
-def convert_extra_metrics(in_data, common_properties):
+def convert_extra_metrics(in_data, properties_to_ignore):
     for k, v in in_data.items():
-        if k in common_properties:
+        if k in properties_to_ignore:
             continue
         if isinstance(v, bool):
             yield k, {


### PR DESCRIPTION
Previously, I assumed all results generated by Google Benchmark were of 'iteration' type. Now that I have more experience with Google Benchmark, I've started generating aggregate results, which contain some different properties.

This change adds support for aggregate results and should make it easy to add any other result schemas we encounter in the future. For forward-compatibility, unsupported types will generate a warning message but will not fail the test. This makes the conversion tolerant to Google Benchmark adding new measures for existing mechanisms.

This change also uses the Jenkins Benchmark plugin's specific value types for numeric and boolean results. The reason all numbers are treated as floating point is that floating point numbers close enough to a round number seem to lose their decimal point and look like an integer. To make the data type consistent across runs, I'm opting to treat everything as a floating point number.

Follow-up to #275