### PR TITLE
Skip performance tests using a CMake variable

### DIFF
--- a/ament_cmake_google_benchmark/ament_cmake_google_benchmark-extras.cmake
+++ b/ament_cmake_google_benchmark/ament_cmake_google_benchmark-extras.cmake
@@ -25,6 +25,11 @@ macro(_ament_cmake_google_benchmark_find_benchmark)
         "your system to enable these tests (e.g. on Ubuntu/Debian install the "
         "package 'libbenchmark-dev') or get the ament package "
         "'google_benchmark_vendor'")
+    elseif(NOT AMENT_RUN_PERFORMANCE_TESTS)
+      message(STATUS
+        "Performance tests are disabled by default, so Google Benchmark tests "
+        "will be skipped. To enable these tests, set the CMake variable "
+        "'AMENT_RUN_PERFORMANCE_TESTS'.")
     endif()
   endif()
 endmacro()

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -90,7 +90,7 @@ function(ament_add_google_benchmark_test target)
   if(ARG_WORKING_DIRECTORY)
     set(ARG_WORKING_DIRECTORY "WORKING_DIRECTORY" "${ARG_WORKING_DIRECTORY}")
   endif()
-  if(ARG_SKIP_TEST)
+  if(ARG_SKIP_TEST OR NOT AMENT_RUN_PERFORMANCE_TESTS)
     set(ARG_SKIP_TEST "SKIP_TEST")
   endif()
 


### PR DESCRIPTION
These tests can be fairly heavy, so we don't want to run them by default. It would be better if there was a way to skip the tests by default in such a way that they could be specifically un-skipped at runtime, but I can't find a mechanism in CMake or CTest that would allow us to achieve that behavior without leveraging environment variables.