### PR TITLE
Fix skipped test reporting in CTest

### DIFF
--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -130,7 +130,7 @@ function(ament_add_test testname)
     "${testname}"
     PROPERTIES TIMEOUT ${ARG_TIMEOUT}
   )
-  if(ARG_SKIP_RETURN_CODE)
+  if(DEFINED ARG_SKIP_RETURN_CODE)
     set_tests_properties(
       "${testname}"
       PROPERTIES SKIP_RETURN_CODE ${ARG_SKIP_RETURN_CODE}


### PR DESCRIPTION
This is a follow-up to #243. When the `SKIP_RETURN_CODE` gets set to 0, the value is interpreted as 'false', and the test property is never actually added.