### PR TITLE
Check condition attribute in package.xml dependencies

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -16,7 +16,7 @@
 
 import argparse
 from collections import OrderedDict
-from os import environ
+import os
 import sys
 
 from catkin_pkg.package import evaluate_condition
@@ -66,14 +66,14 @@ def main(argv=sys.argv[1:]):
 
 
 def get_dependency_values(key, depends):
-    # Filter the incoming dependencies to check for any conditions they might have
-    filtered_depends = []
-    for d in depends:
-        if d.condition is None or d.evaluate_condition(environ):
-            filtered_depends.append(d)
-
     dependencies = []
-    dependencies.append((key, ' '.join(['"%s"' % str(d) for d in filtered_depends])))
+
+    # Filter the dependencies, checking for any condition attributes
+    dependencies.append((key, ' '.join([
+        '"%s"' % str(d) for d in depends
+        if d.condition is None or d.evaluate_condition(os.environ)
+    ])))
+
     for d in depends:
         comparisons = [
             'version_lt',

--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -16,8 +16,10 @@
 
 import argparse
 from collections import OrderedDict
+from os import environ
 import sys
 
+from catkin_pkg.package import evaluate_condition
 from catkin_pkg.package import parse_package_string
 
 
@@ -64,8 +66,14 @@ def main(argv=sys.argv[1:]):
 
 
 def get_dependency_values(key, depends):
+    # Filter the incoming dependencies to check for any conditions they might have
+    filtered_depends = []
+    for d in depends:
+        if d.condition is None or d.evaluate_condition(environ):
+            filtered_depends.append(d)
+
     dependencies = []
-    dependencies.append((key, ' '.join(['"%s"' % str(d) for d in depends])))
+    dependencies.append((key, ' '.join(['"%s"' % str(d) for d in filtered_depends])))
     for d in depends:
         comparisons = [
             'version_lt',


### PR DESCRIPTION
The condition attribute was already parsed when reading the XML file. Just needed to check the condition when adding 
 dependencies to the list for a particular key/target. This will allow conditions to be used for any of the package dependencies ('depend', 'build_depend', 'test_depend', etc.).

Fixes #266

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>