### PR TITLE
Make ament_cmake_test a dep of ament_cmake_google_benchmark

### DIFF
--- a/ament_cmake_google_benchmark/CMakeLists.txt
+++ b/ament_cmake_google_benchmark/CMakeLists.txt
@@ -3,9 +3,12 @@ project(ament_cmake_google_benchmark NONE)
 
 # find dependencies
 find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_export_dependencies REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
+
+ament_export_dependencies(ament_cmake_test)
 
 ament_package(
   CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake"

--- a/ament_cmake_google_benchmark/package.xml
+++ b/ament_cmake_google_benchmark/package.xml
@@ -10,6 +10,7 @@
   <author>Scott K Logan</author>
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>ament_cmake_test</exec_depend>


### PR DESCRIPTION
This hasn't been a problem yet because we've always had `find_package(ament_cmake_test)` (or more commonly, something that depends on it, like `ament_lint_auto`) within the same scope that we `find_package(ament_cmake_google_benchmark)`. We need this dependency because the macros defined by this package invoke `ament_add_test()`.