### PR TITLE
Handle runtime failures in Google Benchmark

### DIFF
--- a/ament_cmake_google_benchmark/doc/benchmark_schema.json
+++ b/ament_cmake_google_benchmark/doc/benchmark_schema.json
@@ -1,7 +1,7 @@
 {
   "description": "Jenkins Benchmark schema for ROS performance test results",
   "failure": {
-    "value": true
+    "value": "failure"
   },
   "type": "object",
   "additionalProperties": {


### PR DESCRIPTION
This change will handle runtime failures in Google Benchmark by propagating error information from Google Benchmark to both CTest and the Jenkins benchmark plugin.

The change to `benchmark_schema.json` will need to be propagated to `ros_buildfarm_config` for this change to be effective.