### PR TITLE
Disable gtest warning when building in Release

### DIFF
--- a/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
+++ b/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
@@ -87,6 +87,9 @@ macro(_ament_cmake_gtest_find_gtest)
         # mark gtest targets with EXCLUDE_FROM_ALL to only build
         # when tests are built which depend on them
         set_target_properties(gtest gtest_main PROPERTIES EXCLUDE_FROM_ALL 1)
+        if(NOT WIN32)
+          target_compile_options(gtest PRIVATE -Wno-null-dereference)
+        endif()
         target_include_directories(gtest BEFORE PUBLIC "${GTEST_FROM_SOURCE_INCLUDE_DIRS}")
         target_include_directories(gtest_main BEFORE PUBLIC "${GTEST_FROM_SOURCE_INCLUDE_DIRS}")
       endif()


### PR DESCRIPTION
A lot of warnings appear when compiling in release, which becomes a blocking issue if your package uses `-Werror=null-dereference`.

This removes PR this warning (or error) from the gtest target.

Also discussed but ignored here: 
https://github.com/google/googletest/issues/1303
```
In file included from /root/control/src/pal_statistics/pal_statistics/src/registration_list.cpp:1:
/root/control/src/pal_statistics/pal_statistics/src/registration_list.h: In constructor ‘pal_statistics::RegistrationList::RegistrationList(const std::shared_ptr<rclcpp::Node>&, size_t)’:
/root/control/src/pal_statistics/pal_statistics/src/registration_list.h:70:33: warning: ‘pal_statistics::RegistrationList::node_’ will be initialized after [-Wreorder]
   70 |   std::shared_ptr<rclcpp::Node> node_;
      |                                 ^~~~~
/root/control/src/pal_statistics/pal_statistics/src/registration_list.h:63:7: warning:   ‘int pal_statistics::RegistrationList::last_id_’ [-Wreorder]
   63 |   int last_id_;
      |       ^~~~~~~~
/root/control/src/pal_statistics/pal_statistics/src/registration_list.cpp:5:1: warning:   when initialized here [-Wreorder]
    5 | RegistrationList::RegistrationList(const std::shared_ptr<rclcpp::Node> &node, size_t internal_buffer_capacity)
      | ^~~~~~~~~~~~~~~~
In file included from /opt/ros/foxy/src/gtest_vendor/src/gtest-all.cc:41:
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc: In static member function ‘static void testing::internal::PrettyUnitTestResultPrinter::PrintFailedTests(const testing::UnitTest&)’:
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3262:30: error: potential null pointer dereference [-Werror=null-dereference]
 3262 |     if (!test_case.should_run() || (test_case.failed_test_count() == 0)) {
      |          ~~~~~~~~~~~~~~~~~~~~^~
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3262:30: error: potential null pointer dereference [-Werror=null-dereference]
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3267:32: error: potential null pointer dereference [-Werror=null-dereference]
 3267 |       if (!test_info.should_run() || !test_info.result()->Failed()) {
      |            ~~~~~~~~~~~~~~~~~~~~^~
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3267:32: error: potential null pointer dereference [-Werror=null-dereference]
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc: In static member function ‘static void testing::internal::PrettyUnitTestResultPrinter::PrintSkippedTests(const testing::UnitTest&)’:
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3287:30: error: potential null pointer dereference [-Werror=null-dereference]
 3287 |     if (!test_case.should_run() || (test_case.skipped_test_count() == 0)) {
      |          ~~~~~~~~~~~~~~~~~~~~^~
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3287:30: error: potential null pointer dereference [-Werror=null-dereference]
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3292:32: error: potential null pointer dereference [-Werror=null-dereference]
 3292 |       if (!test_info.should_run() || !test_info.result()->Skipped()) {
      |            ~~~~~~~~~~~~~~~~~~~~^~
/opt/ros/foxy/src/gtest_vendor/src/gtest.cc:3292:32: error: potential null pointer dereference [-Werror=null-dereference]
```
