### PR TITLE
[ament_cmake_python] ament_cmake_python_get_python_install_dir public

### DIFF
--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -19,7 +19,7 @@ macro(_ament_cmake_python_register_environment_hook)
   if(NOT DEFINED _AMENT_CMAKE_PYTHON_ENVIRONMENT_HOOK_REGISTERED)
     set(_AMENT_CMAKE_PYTHON_ENVIRONMENT_HOOK_REGISTERED TRUE)
 
-    _ament_cmake_python_get_python_install_dir()
+    ament_cmake_python_get_python_install_dir()
 
     find_package(ament_cmake_core QUIET REQUIRED)
 
@@ -40,7 +40,7 @@ macro(_ament_cmake_python_register_environment_hook)
   endif()
 endmacro()
 
-macro(_ament_cmake_python_get_python_install_dir)
+macro(ament_cmake_python_get_python_install_dir)
   if(NOT DEFINED PYTHON_INSTALL_DIR)
     # avoid storing backslash in cached variable since CMake will interpret it as escape character
     set(_python_code
@@ -68,6 +68,11 @@ macro(_ament_cmake_python_get_python_install_dir)
       CACHE INTERNAL
       "The directory for Python library installation. This needs to be in PYTHONPATH when 'setup.py install' is called.")
   endif()
+endmacro()
+
+macro(_ament_cmake_python_get_python_install_dir)
+    message(DEPRECATION "Prefer using the public interface 'ament_cmake_python_get_python_install_dir'.")
+    ament_cmake_python_get_python_install_dir()
 endmacro()
 
 include("${ament_cmake_python_DIR}/ament_python_install_module.cmake")

--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -19,7 +19,7 @@ macro(_ament_cmake_python_register_environment_hook)
   if(NOT DEFINED _AMENT_CMAKE_PYTHON_ENVIRONMENT_HOOK_REGISTERED)
     set(_AMENT_CMAKE_PYTHON_ENVIRONMENT_HOOK_REGISTERED TRUE)
 
-    ament_cmake_python_get_python_install_dir()
+    _zament_cmake_python_get_python_install_dir()
 
     find_package(ament_cmake_core QUIET REQUIRED)
 
@@ -40,7 +40,7 @@ macro(_ament_cmake_python_register_environment_hook)
   endif()
 endmacro()
 
-macro(ament_cmake_python_get_python_install_dir)
+macro(_ament_cmake_python_get_python_install_dir)
   if(NOT DEFINED PYTHON_INSTALL_DIR)
     # avoid storing backslash in cached variable since CMake will interpret it as escape character
     set(_python_code
@@ -70,10 +70,6 @@ macro(ament_cmake_python_get_python_install_dir)
   endif()
 endmacro()
 
-macro(_ament_cmake_python_get_python_install_dir)
-    message(DEPRECATION "Prefer using the public interface 'ament_cmake_python_get_python_install_dir'.")
-    ament_cmake_python_get_python_install_dir()
-endmacro()
-
 include("${ament_cmake_python_DIR}/ament_python_install_module.cmake")
 include("${ament_cmake_python_DIR}/ament_python_install_package.cmake")
+include("${ament_cmake_python_DIR}/ament_get_python_install_dir.cmake")

--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -19,7 +19,7 @@ macro(_ament_cmake_python_register_environment_hook)
   if(NOT DEFINED _AMENT_CMAKE_PYTHON_ENVIRONMENT_HOOK_REGISTERED)
     set(_AMENT_CMAKE_PYTHON_ENVIRONMENT_HOOK_REGISTERED TRUE)
 
-    _zament_cmake_python_get_python_install_dir()
+    _ament_cmake_python_get_python_install_dir()
 
     find_package(ament_cmake_core QUIET REQUIRED)
 

--- a/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
+++ b/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014 Open Source Robotics Foundation, Inc.
+# Copyright 2014-2020 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
+++ b/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
@@ -19,11 +19,11 @@
 #   Python installation directory.
 # :type package_name: string
 #
-macro(ament_get_python_install_dir python_install_dir_out)
+function(ament_get_python_install_dir python_install_dir_out)
   _ament_cmake_python_get_python_install_dir()
   if(NOT PYTHON_INSTALL_DIR)
     message(FATAL_ERROR "ament_get_python_install_dir() variable "
       "'PYTHON_INSTALL_DIR' must not be empty")
   endif()
-  set(${python_install_dir_out} ${PYTHON_INSTALL_DIR})
-endmacro()
+  set(${python_install_dir_out} ${PYTHON_INSTALL_DIR} PARENT_SCOPE)
+endfunction()

--- a/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
+++ b/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
@@ -1,0 +1,29 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Get the Python installation directory.
+#
+# :param python_install_dir_out: this var will be populated with the path to the
+#   Python installation directory.
+# :type package_name: string
+#
+macro(ament_get_python_install_dir python_install_dir_out)
+  _ament_cmake_python_get_python_install_dir()
+  if(NOT PYTHON_INSTALL_DIR)
+    message(FATAL_ERROR "ament_get_python_install_dir() variable "
+      "'PYTHON_INSTALL_DIR' must not be empty")
+  endif()
+  set(${python_install_dir_out} ${PYTHON_INSTALL_DIR})
+endmacro()


### PR DESCRIPTION
## Description

This PR has for purpose to answer the issue https://github.com/ament/ament_cmake/issues/277

## What has been changed?

A new macro `ament_get_python_install_dir` allow the user to access the python installation directory.

## example of usage

```cmake
ament_get_python_install_dir(path_to_python_install_dir)
install(python_bindings_target DESTINATION ${path_to_python_install_dir}/${PROJECT_NAME})
```