### PR TITLE
[backport] [foxy] Add SYSTEM keyword option to ament_target_dependencies (#297) 

### DIFF
--- a/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
+++ b/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
@@ -27,13 +27,12 @@
 #
 # :param target: the target name
 # :type target: string
-# :param ARGN: a list of package names, which can optionally start with an
-#   INTERFACE or PUBLIC keyword.
-#   If it starts with INTERFACE or PUBLIC, this keyword is used in the
-#   target_* calls.
-#   SYSTEM keyword.
-#   If the SYSTEM keyword is specified, it will be added to the
-#   target_include_directories calls.
+# :param ARGN: a list of package names, which can optionally start
+#   with a SYSTEM keyword, followed by an INTERFACE or PUBLIC keyword.
+#   If it starts with a SYSTEM keyword, it will be used in
+#   target_include_directories() calls.
+#   If it starts (or follows) with an INTERFACE or PUBLIC keyword,
+#   this keyword will be used in the target_*() calls.
 # :type ARGN: list of strings
 #
 # @public
@@ -44,24 +43,29 @@ function(ament_target_dependencies target)
   endif()
   if(${ARGC} GREATER 0)
     cmake_parse_arguments(ARG "INTERFACE;PUBLIC;SYSTEM" "" "" ${ARGN})
+    set(ARGVIND 1)
+    set(system_keyword "")
     set(optional_keyword "")
     set(required_keyword "PUBLIC")
+    if(ARG_SYSTEM)
+      if(NOT "${ARGV${ARGVIND}}" STREQUAL "SYSTEM")
+        message(FATAL_ERROR "ament_target_dependencies() SYSTEM keyword is only allowed before the package names and other keywords")
+      endif()
+      set(system_keyword SYSTEM)
+      math(EXPR ARGVIND "${ARGVIND} + 1")
+    endif()
     if(ARG_INTERFACE)
-      if(NOT "${ARGV1}" STREQUAL "INTERFACE")
+      if(NOT "${ARGV${ARGVIND}}" STREQUAL "INTERFACE")
         message(FATAL_ERROR "ament_target_dependencies() INTERFACE keyword is only allowed before the package names")
       endif()
       set(optional_keyword INTERFACE)
       set(required_keyword INTERFACE)
     endif()
     if(ARG_PUBLIC)
-      if(NOT "${ARGV1}" STREQUAL "PUBLIC")
+      if(NOT "${ARGV${ARGVIND}}" STREQUAL "PUBLIC")
         message(FATAL_ERROR "ament_target_dependencies() PUBLIC keyword is only allowed before the package names")
       endif()
       set(optional_keyword PUBLIC)
-    endif()
-    set(system_keyword "")
-    if(ARG_SYSTEM)
-      set(system_keyword SYSTEM)
     endif()
     set(definitions "")
     set(include_dirs "")

--- a/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
+++ b/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
@@ -31,6 +31,9 @@
 #   INTERFACE or PUBLIC keyword.
 #   If it starts with INTERFACE or PUBLIC, this keyword is used in the
 #   target_* calls.
+#   SYSTEM keyword.
+#   If the SYSTEM keyword is specified, it will be added to the
+#   target_include_directories calls.
 # :type ARGN: list of strings
 #
 # @public
@@ -40,7 +43,7 @@ function(ament_target_dependencies target)
     message(FATAL_ERROR "ament_target_dependencies() the first argument must be a valid target name")
   endif()
   if(${ARGC} GREATER 0)
-    cmake_parse_arguments(ARG "INTERFACE;PUBLIC" "" "" ${ARGN})
+    cmake_parse_arguments(ARG "INTERFACE;PUBLIC;SYSTEM" "" "" ${ARGN})
     set(optional_keyword "")
     set(required_keyword "PUBLIC")
     if(ARG_INTERFACE)
@@ -55,6 +58,10 @@ function(ament_target_dependencies target)
         message(FATAL_ERROR "ament_target_dependencies() PUBLIC keyword is only allowed before the package names")
       endif()
       set(optional_keyword PUBLIC)
+    endif()
+    set(system_keyword "")
+    if(ARG_SYSTEM)
+      set(system_keyword SYSTEM)
     endif()
     set(definitions "")
     set(include_dirs "")
@@ -127,13 +134,13 @@ function(ament_target_dependencies target)
       ament_include_directories_order(ordered_interface_include_dirs ${interface_include_dirs})
       # the interface include dirs are used privately to ensure proper order
       # and the interfaces cover the public case
-      target_include_directories(${target}
+      target_include_directories(${target} ${system_keyword}
         PRIVATE ${ordered_interface_include_dirs})
     endif()
     ament_include_directories_order(ordered_include_dirs ${include_dirs})
     target_link_libraries(${target}
       ${optional_keyword} ${interfaces})
-    target_include_directories(${target}
+    target_include_directories(${target} ${system_keyword}
       ${required_keyword} ${ordered_include_dirs})
     if(NOT ARG_INTERFACE)
       ament_libraries_deduplicate(unique_libraries ${libraries})


### PR DESCRIPTION
(Also), Force SYSTEM keyword in ament_target_dependencies() at the start. (#303)

---

Full Foxy CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13036)](http://ci.ros2.org/job/ci_linux/13036/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7984)](http://ci.ros2.org/job/ci_linux-aarch64/7984/) (`sros2` CLI test failures)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10760)](http://ci.ros2.org/job/ci_osx/10760/) (`sros2`, `ros2doctor`, `laser_geometry` test failures)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13016)](http://ci.ros2.org/job/ci_windows/13016/) (`ros2bag` and `rqt_py_common` test failures)
