### PR TITLE
Serialize benchmarks within CTest by default

### DIFF
--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark.cmake
@@ -34,6 +34,9 @@
 # :param WORKING_DIRECTORY: the working directory for invoking the
 #   executable in, default defined by ``ament_add_test()``
 # :type WORKING_DIRECTORY: string
+# :param RUN_PARALLEL: if set allow the test to be run in parallel
+#   with other tests
+# :type RUN_PARALLEL: option
 # :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the google
 #   benchmark main libraries
 # :type SKIP_LINKING_MAIN_LIBRARIES: option
@@ -52,7 +55,7 @@
 #
 macro(ament_add_google_benchmark target)
   cmake_parse_arguments(_ARG
-    "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
+    "RUN_PARALLEL;SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
     "RUNNER;TIMEOUT;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
     ${ARGN})
@@ -79,6 +82,9 @@ macro(ament_add_google_benchmark target)
   endif()
   if(_ARG_WORKING_DIRECTORY)
     list(APPEND _argn_test "WORKING_DIRECTORY" "${_ARG_WORKING_DIRECTORY}")
+  endif()
+  if(_ARG_RUN_PARALLEL)
+    list(APPEND _argn_test "RUN_PARALLEL")
   endif()
   if(_ARG_SKIP_TEST)
     list(APPEND _argn_test "SKIP_TEST")

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -30,6 +30,9 @@
 # :param WORKING_DIRECTORY: the working directory for invoking the
 #   executable in, default defined by ``ament_add_test()``
 # :type WORKING_DIRECTORY: string
+# :param RUN_PARALLEL: if set allow the test to be run in parallel
+#   with other tests
+# :type RUN_PARALLEL: option
 # :param SKIP_TEST: if set mark the test as being skipped
 # :type SKIP_TEST: option
 # :param ENV: list of env vars to set; listed as ``VAR=value``
@@ -49,7 +52,7 @@ function(ament_add_google_benchmark_test target)
   endif()
 
   cmake_parse_arguments(ARG
-    "SKIP_TEST"
+    "RUN_PARALLEL;SKIP_TEST"
     "RUNNER;TIMEOUT;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
     ${ARGN})
@@ -90,6 +93,9 @@ function(ament_add_google_benchmark_test target)
   if(ARG_WORKING_DIRECTORY)
     set(ARG_WORKING_DIRECTORY "WORKING_DIRECTORY" "${ARG_WORKING_DIRECTORY}")
   endif()
+  if(NOT ARG_RUN_PARALLEL)
+    set(PROP_RUN_SERIAL "RUN_SERIAL" "TRUE")
+  endif()
   if(ARG_SKIP_TEST OR NOT AMENT_RUN_PERFORMANCE_TESTS)
     set(ARG_SKIP_TEST "SKIP_TEST")
   endif()
@@ -111,6 +117,6 @@ function(ament_add_google_benchmark_test target)
     PROPERTIES
     REQUIRED_FILES "${executable}"
     LABELS "google_benchmark;performance"
-    RUN_SERIAL TRUE
+    ${PROP_RUN_SERIAL}
   )
 endfunction()

--- a/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
+++ b/ament_cmake_google_benchmark/cmake/ament_add_google_benchmark_test.cmake
@@ -111,5 +111,6 @@ function(ament_add_google_benchmark_test target)
     PROPERTIES
     REQUIRED_FILES "${executable}"
     LABELS "google_benchmark;performance"
+    RUN_SERIAL TRUE
   )
 endfunction()


### PR DESCRIPTION
This flag will instruct CTest to never run benchmarks in parallel with other benchmarks or tests within the same invocation. It won't prevent colcon from invoking multiple CTest instances.

https://cmake.org/cmake/help/latest/prop_test/RUN_SERIAL.html