### PR TITLE
Fix variable name in ament_export_libraries.cmake

### DIFF
--- a/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake
+++ b/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake
@@ -89,7 +89,7 @@ macro(ament_export_libraries)
             foreach(_cfg ${_imported_configurations})
               get_target_property(_imported_location_${_cfg} "${_lib}"
                 IMPORTED_LOCATION_${_cfg})
-              if(_imported_location_${cfg})
+              if(_imported_location_${_cfg})
                 list(APPEND _imported_libraries ${_imported_location_${_cfg}})
               endif()
             endforeach()


### PR DESCRIPTION
Related with this PR https://github.com/ament/ament_cmake/issues/312

Signed-off-by: ahcorde <ahcorde@gmail.com>