### PR TITLE
Fix ament_get_pytest_cov_version for newer versions of pytest

### DIFF
--- a/ament_cmake_pytest/cmake/ament_get_pytest_cov_version.cmake
+++ b/ament_cmake_pytest/cmake/ament_get_pytest_cov_version.cmake
@@ -35,7 +35,8 @@ function(ament_get_pytest_cov_version var)
     set(ARG_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
   endif()
 
-  set(cmd "${ARG_PYTHON_EXECUTABLE}" "-m" "pytest" "--version")
+  # Newer versions of pytest require providing '--version' twice to include plugin versions
+  set(cmd "${ARG_PYTHON_EXECUTABLE}" "-m" "pytest" "--version" "--version")
   execute_process(
     COMMAND ${cmd}
     RESULT_VARIABLE res
@@ -44,7 +45,7 @@ function(ament_get_pytest_cov_version var)
   if(res EQUAL 0)
     # check if pytest-cov is in the list of plugins
     # (actual output of the command is in ${error} and not ${output})
-    string(REGEX MATCH "pytest-cov-([0-9]\.[0-9]\.[0-9])" pytest_cov_full_version "${error}")
+    string(REGEX MATCH "pytest-cov-([0-9]+\.[0-9]+\.[0-9]+)" pytest_cov_full_version "${error}")
     if(pytest_cov_full_version)
       set(${var} ${CMAKE_MATCH_1} PARENT_SCOPE)
     else()


### PR DESCRIPTION
Newer versions of pytest do not display plugin versions by default. They require providing the `--version` option twice. See https://github.com/pytest-dev/pytest/pull/7169.

```sh
$ python3 -m pytest --version
pytest 6.2.1
$ python3 -m pytest --version --version
This is pytest version 6.2.1, imported from /home/chris/.local/lib/python3.8/site-packages/pytest/__init__.py
setuptools registered plugins:
  pytest-cov-2.10.1 at /home/chris/.local/lib/python3.8/site-packages/pytest_cov/plugin.py
  pytest-repeat-0.9.1 at /home/chris/.local/lib/python3.8/site-packages/pytest_repeat.py
  pytest-rerunfailures-9.1.1 at /home/chris/.local/lib/python3.8/site-packages/pytest_rerunfailures.py
  colcon-core-0.6.1 at /home/chris/.local/lib/python3.8/site-packages/colcon_core/pytest/hooks.py
  pytest-mock-1.10.4 at /usr/lib/python3/dist-packages/pytest_mock.py
```

It also works fine on older versions (using `sudo` here to use the version installed from `apt`).

```sh
$ sudo python3 -m pytest --version
This is pytest version 4.6.9, imported from /usr/lib/python3/dist-packages/pytest.py
setuptools registered plugins:
  pytest-cov-2.8.1 at /usr/lib/python3/dist-packages/pytest_cov/plugin.py
  colcon-core-0.6.1 at /usr/lib/python3/dist-packages/colcon_core/pytest/hooks.py
  pytest-mock-1.10.4 at /usr/lib/python3/dist-packages/pytest_mock.py
$ sudo python3 -m pytest --version --version
This is pytest version 4.6.9, imported from /usr/lib/python3/dist-packages/pytest.py
setuptools registered plugins:
  pytest-cov-2.8.1 at /usr/lib/python3/dist-packages/pytest_cov/plugin.py
  colcon-core-0.6.1 at /usr/lib/python3/dist-packages/colcon_core/pytest/hooks.py
  pytest-mock-1.10.4 at /usr/lib/python3/dist-packages/pytest_mock.py
```

Finally, fix version regex for pytest-cov.