### PR TITLE
Use DESTDIR on ament_python_install_package()

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -134,19 +134,18 @@ setup(
 
   # Install as flat Python .egg to mimic https://github.com/colcon/colcon-core
   # handling of pure Python packages.
-  file(RELATIVE_PATH install_dir "${build_dir}" "${CMAKE_INSTALL_PREFIX}")
 
   # NOTE(hidmic): Allow setup.py install to build, as there is no way to
   # determine the Python package's source dependencies for proper build
   # invalidation.
   install(CODE
     "message(STATUS \"Installing: ${package_name} as flat Python egg \"
-                    \"to ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}\")
+                    \"to \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}\")
      execute_process(
         COMMAND
         \"${PYTHON_EXECUTABLE}\" setup.py install
            --single-version-externally-managed
-           --prefix \"${install_dir}\"
+           --prefix \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}\"
            --record install.log
            ${extra_install_args}
         WORKING_DIRECTORY \"${build_dir}\"


### PR DESCRIPTION
Follow up after #316. This patch should solve the [regression](https://build.ros2.org/view/Rbin_uF64/job/Rbin_uF64__ament_cmake_python__ubuntu_focal_amd64__binary/20/console) introduced in debian builds.