### PR TITLE
Escape $ENV{DESTDIR} everywhere in ament_python_install_package()

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -141,7 +141,7 @@ setup(
   install(CODE
     "set(extra_install_args ${extra_install_args})
      set(install_dir \"${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}\")
-     if(DEFINED ENV{DESTDIR} AND NOT \"$ENV{DESTDIR}\" STREQUAL \"\")
+     if(DEFINED ENV{DESTDIR} AND NOT \"\$ENV{DESTDIR}\" STREQUAL \"\")
        list(APPEND extra_install_args --root \$ENV{DESTDIR})
        file(TO_CMAKE_PATH \"\$ENV{DESTDIR}/\${install_dir}\" install_dir)
      endif()


### PR DESCRIPTION
Follow up after #323. Massive :facepalm: 

