### PR TITLE
Symlink setup.cfg and sources before building Python egg-info

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -93,24 +93,28 @@ setup(
     CONTENT "${setup_py_content}"
   )
 
+  set(egg_dependencies ament_cmake_python_symlink_${package_name})
+
+  add_custom_target(
+    ament_cmake_python_symlink_${package_name}
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    "${ARG_PACKAGE_DIR}" "${build_dir}/${package_name}"
+  )
+
   if(ARG_SETUP_CFG)
     add_custom_target(
-      ament_cmake_python_symlink_${package_name}_setup ALL
+      ament_cmake_python_symlink_${package_name}_setup
       COMMAND ${CMAKE_COMMAND} -E create_symlink
         "${ARG_SETUP_CFG}" "${build_dir}/setup.cfg"
     )
+    list(APPEND egg_dependencies ament_cmake_python_symlink_${package_name}_setup)
   endif()
-
-  add_custom_target(
-    ament_cmake_python_symlink_${package_name} ALL
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-      "${ARG_PACKAGE_DIR}" "${build_dir}/${package_name}"
-  )
 
   add_custom_target(
     ament_cmake_python_build_${package_name}_egg ALL
     COMMAND ${PYTHON_EXECUTABLE} setup.py egg_info
     WORKING_DIRECTORY "${build_dir}"
+    DEPENDS ${egg_dependencies}
   )
 
   install(


### PR DESCRIPTION
Follow-up after #326. There should be a _Here be dragons_ sign in `ament_cmake` root README...

CI up to `rosidl_adapter` (at https://github.com/ros2/rosidl/pull/576, to exercise this regression):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13853)](http://ci.ros2.org/job/ci_linux/13853/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8709)](http://ci.ros2.org/job/ci_linux-aarch64/8709/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11561)](http://ci.ros2.org/job/ci_osx/11561/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13941)](http://ci.ros2.org/job/ci_windows/13941/)

