### PR TITLE
Make ament_python_install_package() install console_scripts

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -112,7 +112,8 @@ setup(
 
   add_custom_target(
     ament_cmake_python_build_${package_name}_egg ALL
-    COMMAND ${PYTHON_EXECUTABLE} setup.py egg_info
+    COMMAND ${PYTHON_EXECUTABLE} setup.py
+      egg_info install_scripts -d scripts
     WORKING_DIRECTORY "${build_dir}"
     DEPENDS ${egg_dependencies}
   )
@@ -120,6 +121,11 @@ setup(
   install(
     DIRECTORY "${build_dir}/${package_name}.egg-info"
     DESTINATION "${PYTHON_INSTALL_DIR}/"
+  )
+
+  install(
+    DIRECTORY "${build_dir}/scripts/"
+    DESTINATION "lib/${package_name}/"
   )
 
   install(

--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -110,6 +110,8 @@ setup(
     list(APPEND egg_dependencies ament_cmake_python_symlink_${package_name}_setup)
   endif()
 
+  file(MAKE_DIRECTORY "${build_dir}/scripts")  # setup.py may or may not create it
+
   add_custom_target(
     ament_cmake_python_build_${package_name}_egg ALL
     COMMAND ${PYTHON_EXECUTABLE} setup.py


### PR DESCRIPTION
Precisely what the title says. A nice to have, addressing https://github.com/ament/ament_cmake/issues/213.

Preliminary CI up to `ament_cmake_python` (no core packages exercises the feature):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13910)](http://ci.ros2.org/job/ci_linux/13910/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8759)](http://ci.ros2.org/job/ci_linux-aarch64/8759/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11617)](http://ci.ros2.org/job/ci_osx/11617/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13999)](http://ci.ros2.org/job/ci_windows/13999/)

