### PR TITLE
Fix missed reporting of failures from command segfaults or timeouts

### DIFF
--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -117,7 +117,7 @@ def main(argv=sys.argv[1:]):
     # in case the command segfaults or timeouts and does not generate one
     failure_result_file = _generate_result(
         args.result_file,
-        error_message='The test did not generate a result file.')
+        failure_message='The test did not generate a result file.')
     with open(args.result_file, 'w') as h:
         h.write(failure_result_file)
 


### PR DESCRIPTION
Set `failure_message` rather than `error_message` in case the command segfaults or timeouts and does not generate results, given the `failures` attribute for the `testcase` element is determined by whether the `failure_message` parameter is non-empty:

https://github.com/ament/ament_cmake/blob/84719051ef2b26070de484e60b8f060ae7a70b06/ament_cmake_test/ament_cmake_test/__init__.py#L331-L339

cc @hidmic