### PR TITLE
Add note regarding interface libraries

### DIFF
--- a/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake
+++ b/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake
@@ -18,6 +18,7 @@
 # :param ARGN: a list of libraries.
 #   Each element might either be an absolute path to a library, a
 #   CMake library target, or a CMake imported libary target.
+#   Note that this macro is not needed for interface library targets.
 #   If a plain library name is passed it will be redirected to
 #   ament_export_library_names().
 # :type ARGN: list of strings


### PR DESCRIPTION
I was curious how to export a header only library and manage its dependencies in a modern way.
When I was importing my header only library, CMake complained that it couldn't find the library, so I removed `ament_export_libraries`. Please find a MWE [here](https://github.com/gleichdick/ros2_header_only_lib), did I use all the ament macros as expected? If yes, I'm happy to write a tutorial, please point me to the place where I can submit a PR for it.