### PR TITLE
Modify ament_cmake_export_targets to also create a namespaced local alias of the exported target

### DIFF
--- a/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
+++ b/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
@@ -31,5 +31,13 @@ if(NOT _AMENT_CMAKE_EXPORT_TARGETS STREQUAL "")
       NAMESPACE "${PROJECT_NAME}::"
       FILE "${_target}Export.cmake"
     )
+    # Create namespaced alias of the target so it can be linked
+    # as ${PROJECT_NAME}::${_target} both if the project is included 
+    # via find_package or via add_subdirectory
+    # If ${PROJECT_NAME}::${_target} is already defined we do not 
+    # define it to avoid creating problems in projects that already define it
+    if(TARGET ${_target} AND NOT TARGET ${PROJECT_NAME}::${_target})
+      add_library(${PROJECT_NAME}::${_target} ALIAS ${_target})
+    endif()
   endforeach()
 endif()


### PR DESCRIPTION
A common practice in "modern" CMake development practices is to always add a namespaced `ALIAS` target for each library that is installed with a given namespace, to ensure that the library can be consumed as `target_link([...] <pkg>::<target_name>)` both if the project is used via `find_package(<pkg>)` or via `FetchContent/add_subdirectory` . For more details on this, see (among other resources):
* https://cliutils.gitlab.io/modern-cmake/chapters/install.html
* https://www.youtube.com/watch?v=bsXLMQ6WgIk&t=3126s

I was trying to follow this practice in an existing project that was creating a type support library via rosidl, see  https://github.com/robotology-playground/yarp-ros2/pull/10 . By doing so, I noticed that if I included the library via `add_subdirectory` the created target was named `map2d_nws_ros2_msgs__rosidl_typesupport_cpp`, while if I was including the project via `find_package` the target was named `map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp`. As a workaround, I simply added the alias myself, as in:
~~~
if(NOT TARGET map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
    add_library(map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp ALIAS map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
  endif()
~~~

However, I looked of how we could avoid to have such boilerplate. Initially, I tried to modify rosidl's macro that were calling `add_library` in the first place. However, I then tought that it would be more effective to try to do this exactly where the namespace of the installed library was set to `${PROJECT_NAME}`, also to make more projects benefit of this change. However, I am definitely not an `ament` expert, so I opened this PR mainly to collect more feedback in how to do this. For example, I am not sure if it would make sense to do a similar change also in https://github.com/ament/ament_cmake/blob/84719051ef2b26070de484e60b8f060ae7a70b06/ament_cmake_export_interfaces/cmake/ament_cmake_export_interfaces_package_hook.cmake#L31 .

I am also not sure if the CHANGELOG in https://github.com/ament/ament_cmake/blob/master/ament_cmake_export_targets/CHANGELOG.rst should be updated, I looked into similar PRs and I never see the CHANGELOG updated, so I don't know what's the recommended practice w.r.t. to that. 

In a sense, this change should simplify using ROS2 libraries with pure CMake workflows and projects, basically going into the direction discussed of improving the "Ease of use of ROS software from outside ROS" as discussed in https://discourse.ros.org/t/migrating-ros-ros2-off-of-catkin-colcon-towards-pure-cmake/12104/16 .