### PR TITLE
add note regarding SYSTEM usage for ament_target_dependencies

### DIFF
--- a/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
+++ b/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
@@ -31,6 +31,10 @@
 #   with a SYSTEM keyword, followed by an INTERFACE or PUBLIC keyword.
 #   If it starts with a SYSTEM keyword, it will be used in
 #   target_include_directories() calls.
+#   Do not use the SYSTEM keyword for other ROS dependencies
+#   (targets build in a ROS workspace, to be precise),
+#   as build errors could arise when overlaying workspaces.
+#   See `here <https://github.com/ros-planning/geometric_shapes/pull/186#discussion_r623989443>`_ for details.
 #   If it starts (or follows) with an INTERFACE or PUBLIC keyword,
 #   this keyword will be used in the target_*() calls.
 # :type ARGN: list of strings


### PR DESCRIPTION
As discussed in ros-planning/warehouse_ros#86 and [here](https://github.com/ros-planning/geometric_shapes/pull/186#discussion_r623989443), using the `SYSTEM` directive for ROS packages in `ament_target_dependencies` should be discouraged because of gcc's `-isystem` behaviour.