### PR TITLE
Make ament_include_directories_order a function to allow paths with backslashes on windows.

### DIFF
--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -27,11 +27,12 @@ macro(ament_include_directories_order var)
   if(WIN32)
     # Paths on windows may use back-slashes c:\Python3.8\...
     # Replace with forward-slashes so CMake doesn't treat them as escape characters below
-    string(REPLACE "\\" "/" _ament_prefix_path_list ${_ament_prefix_path_list})
+    string(REPLACE "\\" "/" _ament_all_arguments "${ARGN}")
   else()
+    set(_ament_all_arguments "${ARGN}")
     string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")
   endif()
-  _ament_include_directories_order(${var} "${_ament_prefix_path_list}" ${ARGN})
+  _ament_include_directories_order(${var} "${_ament_prefix_path_list}" ${_ament_all_arguments})
 endmacro()
 
 

--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -27,7 +27,7 @@ macro(ament_include_directories_order var)
   if(WIN32)
     # Paths on windows may use back-slashes c:\Python3.8\...
     # Replace with forward-slashes so CMake doesn't treat them as escape characters below
-    string(REPLACE "\\" "/" _ament_all_arguments "${ARGN}")
+    string(REPLACE "\\" "/" _ament_all_arguments  ${ARGN})
   else()
     set(_ament_all_arguments "${ARGN}")
     string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")

--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -27,7 +27,7 @@ macro(ament_include_directories_order var)
   if(WIN32)
     # Paths on windows may use back-slashes c:\Python3.8\...
     # Replace with forward-slashes so CMake doesn't treat them as escape characters below
-    string(REPLACE "\\" "/" _ament_prefix_path_list ${_ament_prefix_path_list })
+    string(REPLACE "\\" "/" _ament_prefix_path_list ${_ament_prefix_path_list})
   else()
     string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")
   endif()

--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -22,27 +22,12 @@
 #
 # @public
 #
-macro(ament_include_directories_order var)
-  set(_ament_prefix_path_list "$ENV{AMENT_PREFIX_PATH}")
-  # Must check ARGC because ARG* in CMake macros are string replacements, not true variables.
-  # Not checking leads to string(REPLACE ...) complaining of insufficient number of arguments.
-  # Quotes can't be used because any back slashes cause CMake to look for escape characters
-  if(WIN32 AND ${ARGC} GREATER 1)
-    # Paths on windows may use back-slashes c:\Python38\...
-    # Replace with forward-slashes so CMake doesn't treat them as escape characters below
-    string(REPLACE "\\" "/" _ament_all_arguments  ${ARGN})
-  else()
-    set(_ament_all_arguments "${ARGN}")
-  endif()
-
+function(ament_include_directories_order var)
+  set(prefixes "$ENV{AMENT_PREFIX_PATH}")
   if(NOT WIN32)
-    string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")
+    string(REPLACE ":" ";" prefixes "${prefixes}")
   endif()
-  _ament_include_directories_order(${var} "${_ament_prefix_path_list}" ${_ament_all_arguments})
-endmacro()
 
-
-function(_ament_include_directories_order var prefixes)
   # create list of empty slots, one per prefix and one for unknown prefixes
   list(LENGTH prefixes prefix_count)
   foreach(index RANGE ${prefix_count})

--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -24,7 +24,11 @@
 #
 macro(ament_include_directories_order var)
   set(_ament_prefix_path_list "$ENV{AMENT_PREFIX_PATH}")
-  if(NOT WIN32)
+  if(WIN32)
+    # Paths on windows may use back-slashes c:\Python3.8\...
+    # Replace with forward-slashes so CMake doesn't treat them as escape characters below
+    string(REPLACE "\\" "/" _ament_prefix_path_list ${_ament_prefix_path_list })
+  else()
     string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")
   endif()
   _ament_include_directories_order(${var} "${_ament_prefix_path_list}" ${ARGN})

--- a/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
+++ b/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake
@@ -24,12 +24,18 @@
 #
 macro(ament_include_directories_order var)
   set(_ament_prefix_path_list "$ENV{AMENT_PREFIX_PATH}")
-  if(WIN32)
-    # Paths on windows may use back-slashes c:\Python3.8\...
+  # Must check ARGC because ARG* in CMake macros are string replacements, not true variables.
+  # Not checking leads to string(REPLACE ...) complaining of insufficient number of arguments.
+  # Quotes can't be used because any back slashes cause CMake to look for escape characters
+  if(WIN32 AND ${ARGC} GREATER 1)
+    # Paths on windows may use back-slashes c:\Python38\...
     # Replace with forward-slashes so CMake doesn't treat them as escape characters below
     string(REPLACE "\\" "/" _ament_all_arguments  ${ARGN})
   else()
     set(_ament_all_arguments "${ARGN}")
+  endif()
+
+  if(NOT WIN32)
     string(REPLACE ":" ";" _ament_prefix_path_list "${_ament_prefix_path_list}")
   endif()
   _ament_include_directories_order(${var} "${_ament_prefix_path_list}" ${_ament_all_arguments})


### PR DESCRIPTION
This fixes a CMake error that can happen when include directory paths have back slashes in them on Windows.

I attempted to use answers from a few SO posts: https://stackoverflow.com/questions/13737370/cmake-error-invalid-escape-sequence-u , but replacing the slashes can't be done inside the macro. The problem is `ARGN` isn't a real variable in a CMake macro. Instead it gets substituted as a string. This means the back slashes in the path get evaluated as if the un-escaped string was typed in a CMake file. Making the macro a function should resolve this problem.

```
15:32:23 CMake Error at C:/ci/ws/install/share/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake:30 (_ament_include_directories_order):
15:32:23   Syntax error in cmake code at
15:32:23 
15:32:23     C:/ci/ws/install/share/ament_cmake_include_directories/cmake/ament_include_directories_order.cmake:30
15:32:23 
15:32:23   when parsing string
15:32:23 
15:32:23     C:/ci/ws/install/include;C:\Python38\lib\site-packages\numpy\core\include
15:32:23 
15:32:23   Invalid character escape '\P'.
15:32:23 Call Stack (most recent call first):
15:32:23   C:/ci/ws/install/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:138 (ament_include_directories_order)
15:32:23   C:/ci/ws/install/share/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake:129 (ament_target_dependencies)
15:32:23   C:/ci/ws/install/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
15:32:23   C:/ci/ws/install/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
15:32:23   CMakeLists.txt:17 (rosidl_generate_interfaces)
```

This PR is required to fix https://github.com/ros2/rosidl_python/pull/149 , which itself is required to fix https://github.com/ros2/rcl_interfaces/pull/133