### PR TITLE
Use sysconfig directly to determine python lib dir

### DIFF
--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -44,9 +44,9 @@ macro(_ament_cmake_python_get_python_install_dir)
   if(NOT DEFINED PYTHON_INSTALL_DIR)
     # avoid storing backslash in cached variable since CMake will interpret it as escape character
     set(_python_code
-      "from distutils.sysconfig import get_python_lib"
       "import os"
-      "print(os.path.relpath(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
+      "import sysconfig"
+      "print(os.path.relpath(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
     )
     get_executable_path(_python_interpreter Python3::Interpreter CONFIGURE)
     execute_process(


### PR DESCRIPTION
The distutils package is deprecated and will be removed in Python 3.12. We can achieve the same behavior using sysconfig directly.

Docs for `get_python_lib`: https://docs.python.org/3/distutils/apiref.html#distutils.sysconfig.get_python_lib
Docs for `get_path`: https://docs.python.org/3/library/sysconfig.html#sysconfig.get_path

Note the docs for the `purelib` value read:
> * _purelib: directory for site-specific, non-platform-specific files._

This should resolve build warnings like this:
```
<string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
<string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
```