### PR TITLE
use the error handler replace to allow non-utf8 to be decoded

### DIFF
--- a/ament_cmake_pytest/CMakeLists.txt
+++ b/ament_cmake_pytest/CMakeLists.txt
@@ -4,6 +4,61 @@ project(ament_cmake_pytest NONE)
 
 find_package(ament_cmake_core REQUIRED)
 
+# Even though we theoretically only need this as a test dependency, we
+# have to find it *before* the if(BUILD_TESTING) check since ament_cmake_test
+# is the package that defines that option.
+find_package(ament_cmake_test REQUIRED)
+
+if(BUILD_TESTING)
+  # The test we are enabling below is to test that the code in ament_cmake_test can handle
+  # non-unicode prints on the console. Ideally we would put the test in that package,
+  # but we can't actually use ament_add_test() from within its own package so
+  # we put it here instead. For similar reasons, we don't use ament_add_pytest_test() below since
+  # it is defined in *this* package.
+
+  get_executable_path(python_interpreter Python3::Interpreter CONFIGURE)
+
+  # Check if pytest is available
+  set(check_pytest_cmd "${python_interpreter}" "-m" "pytest" "--version")
+  execute_process(
+    COMMAND ${check_pytest_cmd}
+    RESULT_VARIABLE res
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error)
+  if(NOT res EQUAL 0)
+    message(WARNING
+      "The Python module 'pytest' was not found, pytests cannot be run. "
+      "On Linux, install the 'python3-pytest' package. "
+      "On other platforms, install 'pytest' using pip.")
+    return()
+  endif()
+
+  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/pytest.xunit.xml")
+  set(cmd
+    "${python_interpreter}"
+    "-u"  # unbuffered stdout and stderr
+    "-m" "pytest"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test"
+    # store last failed tests
+    "-o" "cache_dir=${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_pytest/pytest/.cache"
+    "-s"
+    # junit arguments
+    "--junit-xml=${result_file}"
+    "--junit-prefix=${PROJECT_NAME}"
+  )
+  ament_add_test(
+    pytest
+    COMMAND ${cmd}
+    OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_cmake_pytest/pytest.txt"
+    RESULT_FILE "${result_file}"
+  )
+  set_tests_properties(
+    pytest
+    PROPERTIES
+    LABELS "pytest"
+  )
+endif()
+
 ament_package(
   CONFIG_EXTRAS "ament_cmake_pytest-extras.cmake"
 )

--- a/ament_cmake_pytest/test/test_pyunicode.py
+++ b/ament_cmake_pytest/test/test_pyunicode.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+def test_print_unicode():
+    sys.stderr.buffer.write(b'val: ')
+    sys.stderr.buffer.write(b'\xff\x00\xa1')
+    sys.stderr.buffer.write(b'\n')

--- a/ament_cmake_pytest/test/test_pyunicode.py
+++ b/ament_cmake_pytest/test/test_pyunicode.py
@@ -15,6 +15,10 @@
 import sys
 
 def test_print_unicode():
+    '''
+    Print a non UTF-8 byte sequence in a test to verify stderr parsing.
+    This value was originally reported in: https://github.com/colcon/colcon-core/issues/468
+   '''
     sys.stderr.buffer.write(b'val: ')
     sys.stderr.buffer.write(b'\xff\x00\xa1')
     sys.stderr.buffer.write(b'\n')

--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -207,7 +207,7 @@ def _run_test(parser, args, failure_result_file, output_handle):
                 break
             for i, encoding in enumerate(encodings):
                 try:
-                    decoded_line = line.decode(encoding)
+                    decoded_line = line.decode(encoding, errors='surrogateescape')
                 except UnicodeDecodeError:
                     if i == len(encodings) - 1:
                         raise
@@ -216,7 +216,7 @@ def _run_test(parser, args, failure_result_file, output_handle):
             print(decoded_line, end='')
             output += decoded_line
             if output_handle:
-                output_handle.write(decoded_line.encode())
+                output_handle.write(decoded_line.encode(errors='surrogateescape'))
                 output_handle.flush()
         proc.wait()
         rc = proc.returncode

--- a/ament_cmake_test/ament_cmake_test/__init__.py
+++ b/ament_cmake_test/ament_cmake_test/__init__.py
@@ -207,16 +207,16 @@ def _run_test(parser, args, failure_result_file, output_handle):
                 break
             for i, encoding in enumerate(encodings):
                 try:
-                    decoded_line = line.decode(encoding, errors='surrogateescape')
+                    decoded_line = line.decode(encoding)
                 except UnicodeDecodeError:
                     if i == len(encodings) - 1:
-                        raise
+                        decoded_line = line.decode(encoding, errors='replace')
                 else:
                     break
             print(decoded_line, end='')
             output += decoded_line
             if output_handle:
-                output_handle.write(decoded_line.encode(errors='surrogateescape'))
+                output_handle.write(decoded_line.encode())
                 output_handle.flush()
         proc.wait()
         rc = proc.returncode


### PR DESCRIPTION
Fixes #379

Signed-off-by: Alaa <ejalaa12@gmail.com>