### PR TITLE
Rolling: ament_cmake_auto should include dependencies as SYSTEM

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
@@ -81,7 +81,7 @@ macro(ament_auto_add_executable target)
   endif()
 
   # add exported information from found build dependencies
-  ament_target_dependencies(${target} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
 
   list(APPEND ${PROJECT_NAME}_EXECUTABLES "${target}")
 endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
@@ -73,11 +73,7 @@ macro(ament_auto_add_executable target)
   # link against other libraries of this package
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
       NOT ARG_NO_TARGET_LINK_LIBRARIES)
-    foreach(lib ${${PROJECT_NAME}_LIBRARIES})
-      get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
-      target_include_directories("${target}" SYSTEM PRIVATE ${lib_include_dirs})
-      target_link_libraries("${target}" ${lib})
-    endforeach(lib)
+    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
   endif()
 
   # add exported information from found build dependencies

--- a/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
@@ -73,7 +73,11 @@ macro(ament_auto_add_executable target)
   # link against other libraries of this package
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
       NOT ARG_NO_TARGET_LINK_LIBRARIES)
-    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+    foreach(lib ${${PROJECT_NAME}_LIBRARIES})
+      get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
+      target_include_directories("${target}" SYSTEM PRIVATE ${lib_include_dirs})
+      target_link_libraries("${target}" ${lib})
+    endforeach(lib)
   endif()
 
   # add exported information from found build dependencies

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -67,13 +67,17 @@ macro(ament_auto_add_library target)
 
   # add include directory of this package if it exists
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    target_include_directories("${target}" PUBLIC
+    target_include_directories("${target}" SYSTEM
       "${CMAKE_CURRENT_SOURCE_DIR}/include")
   endif()
   # link against other libraries of this package
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
       NOT ARG_NO_TARGET_LINK_LIBRARIES)
-    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+    foreach(lib ${${PROJECT_NAME}_LIBRARIES})
+      get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
+      target_include_directories("${target}" SYSTEM PRIVATE ${lib_include_dirs})
+      target_link_libraries("${target}" ${lib})
+    endforeach(lib)
   endif()
 
   # add exported information from found build dependencies

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -81,7 +81,7 @@ macro(ament_auto_add_library target)
   endif()
 
   # add exported information from found build dependencies
-  ament_target_dependencies(${target} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
 
   list(APPEND ${PROJECT_NAME}_LIBRARIES "${target}")
 endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -73,11 +73,7 @@ macro(ament_auto_add_library target)
   # link against other libraries of this package
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
       NOT ARG_NO_TARGET_LINK_LIBRARIES)
-    foreach(lib ${${PROJECT_NAME}_LIBRARIES})
-      get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
-      target_include_directories("${target}" SYSTEM PRIVATE ${lib_include_dirs})
-      target_link_libraries("${target}" ${lib})
-    endforeach(lib)
+    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
   endif()
 
   # add exported information from found build dependencies

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -67,7 +67,7 @@ macro(ament_auto_add_library target)
 
   # add include directory of this package if it exists
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    target_include_directories("${target}" SYSTEM
+    target_include_directories("${target}" PUBLIC
       "${CMAKE_CURRENT_SOURCE_DIR}/include")
   endif()
   # link against other libraries of this package


### PR DESCRIPTION
Because of the stricter requirements in C++17 and because the macros ament_auto_add_library and ament_auto_add_executable use target_link_libraries() to link against interfaces exposed by dependencies automatically without any qualifier keywords, many errors are generated from dependencies such as rclcpp when using these macros. This PR modifies these macros to extract the INTERFACE_INCLUDE_DIRECTORIES of interfaces for libraries for the current package and adds them with tthe SYSTEM and PRIVATE keywords to avoid surfacing those errors (which probably should have been the case all along). It also adds the SYSTEM keyword to ament_target_dependencies() for the build depends for the same reason.

Re-created to target `rolling` from #384 .