### PR TITLE
Use posix_prefix scheme to avoid 'local' in path

### DIFF
--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -46,7 +46,7 @@ macro(_ament_cmake_python_get_python_install_dir)
     set(_python_code
       "import os"
       "import sysconfig"
-      "print(os.path.relpath(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}), start='${CMAKE_INSTALL_PREFIX}', scheme='posix_prefix').replace(os.sep, '/'))"
+      "print(os.path.relpath(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}, scheme='posix_prefix'), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
     )
     get_executable_path(_python_interpreter Python3::Interpreter CONFIGURE)
     execute_process(

--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -46,7 +46,7 @@ macro(_ament_cmake_python_get_python_install_dir)
     set(_python_code
       "import os"
       "import sysconfig"
-      "print(os.path.relpath(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
+      "print(os.path.relpath(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}), start='${CMAKE_INSTALL_PREFIX}', scheme='posix_prefix').replace(os.sep, '/'))"
     )
     get_executable_path(_python_interpreter Python3::Interpreter CONFIGURE)
     execute_process(


### PR DESCRIPTION
Follow up from #378 
Matches https://github.com/colcon/colcon-core/pull/504
Related to https://github.com/colcon/colcon-core/issues/503

This uses the `posix_prefix` scheme to avoid a `local/` in the python path.

This should be backported to Humble