### PR TITLE
Fix location for pyc compilation

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_module.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_module.cmake
@@ -65,7 +65,7 @@ function(_ament_cmake_python_install_module module_file)
       "execute_process(
         COMMAND
         \"${python_interpreter}\" \"-m\" \"compileall\"
-        \"${CMAKE_INSTALL_PREFIX}/${destination}/${module_file}\"
+        \"${destination}/${module_file}\"
       )"
     )
   endif()

--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -192,7 +192,7 @@ setup(
       "execute_process(
         COMMAND
         \"${python_interpreter_config}\" \"-m\" \"compileall\"
-        \"${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${package_name}\"
+        \"${ARG_DESTINATION}/${package_name}\"
       )"
     )
   endif()


### PR DESCRIPTION
I've had to patch this in teh RoboStack ros-humble builds because otherwise on macOS we end up with the wrong path (two times the installation prefix concatenated).

