### PR TITLE
[foxy] Revert "Merge pull request #287 from ament/mjeronimo/add-condition-support (#376)"

### DIFF
--- a/ament_cmake_core/cmake/core/package_xml_2_cmake.py
+++ b/ament_cmake_core/cmake/core/package_xml_2_cmake.py
@@ -16,10 +16,8 @@
 
 import argparse
 from collections import OrderedDict
-import os
 import sys
 
-from catkin_pkg.package import evaluate_condition
 from catkin_pkg.package import parse_package_string
 
 
@@ -67,13 +65,7 @@ def main(argv=sys.argv[1:]):
 
 def get_dependency_values(key, depends):
     dependencies = []
-
-    # Filter the dependencies, checking for any condition attributes
-    dependencies.append((key, ' '.join([
-        '"%s"' % str(d) for d in depends
-        if d.condition is None or d.evaluate_condition(os.environ)
-    ])))
-
+    dependencies.append((key, ' '.join(['"%s"' % str(d) for d in depends])))
     for d in depends:
         comparisons = [
             'version_lt',


### PR DESCRIPTION
Revert https://github.com/ament/ament_cmake/pull/376

While it is fixing a bug (ament_cmake ignoring condition attributes), it is a significant behavior change that can cause regressions for packages that are relying on the old behavior (unknowingly or not).

This should fix a regression in [plotjuggler_msgs](https://build.ros2.org/view/Fbin_uF64/job/Fbin_uF64__plotjuggler_msgs__ubuntu_focal_amd64__binary/52/).

