### PR TITLE
Fix deprecation messages always getting silenced.

### DIFF
--- a/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
+++ b/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in
@@ -27,7 +27,7 @@ if(NOT "@PACKAGE_DEPRECATED@" STREQUAL "")
     set(_msg "${_msg} (@PACKAGE_DEPRECATED@)")
   endif()
   # optionally quiet the deprecation message
-  if(NOT ${@PROJECT_NAME@_DEPRECATED_QUIET})
+  if(NOT @PROJECT_NAME@_DEPRECATED_QUIET)
     message(DEPRECATION "${_msg}")
   endif()
 endif()


### PR DESCRIPTION
Fixes a bug that was introduced back in https://github.com/ament/ament_cmake/pull/223, where deprecation via the <deprecation> tag in package.xml was always getting silenced due to the incorrect if statement. The line

```sh
if(NOT ${@PROJECT_NAME@_DEPRECATED_QUIET})
```
always evaluated true.

A short example that reproduces this annoying behaviour of cmake:

```sh
  # "TRUE" gets printed (Correct behaviour)
  if (NOT UNDEFINED_VAR)
    message(STATUS "TRUE")
  else()
    message(STATUS "FALSE")
  endif()

  # "FALSE" gets printed (Unexpected behaviour)
  if (NOT ${UNDEFINED_VAR})
    message(STATUS "TRUE")
  else()
    message(STATUS "FALSE")
  endif()
```

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>