### PR TITLE
Rolling: ament_cmake_auto should include dependencies as SYSTEM (#385)

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
@@ -77,7 +77,7 @@ macro(ament_auto_add_executable target)
   endif()
 
   # add exported information from found build dependencies
-  ament_target_dependencies(${target} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
 
   list(APPEND ${PROJECT_NAME}_EXECUTABLES "${target}")
 endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -77,7 +77,7 @@ macro(ament_auto_add_library target)
   endif()
 
   # add exported information from found build dependencies
-  ament_target_dependencies(${target} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
 
   list(APPEND ${PROJECT_NAME}_LIBRARIES "${target}")
 endmacro()


### PR DESCRIPTION
Backport of #385 to Foxy.