### PR TITLE
ament_python_install_package: exclude libraries from install

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -183,6 +183,7 @@ setup(
     DESTINATION "${ARG_DESTINATION}/${package_name}"
     PATTERN "*.pyc" EXCLUDE
     PATTERN "__pycache__" EXCLUDE
+    PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}" EXCLUDE
   )
 
   if(NOT ARG_SKIP_COMPILE)


### PR DESCRIPTION
hen rosidl_python is run to generate messages, the lib<msgname>__rosidl_generator_py.so (in case of linux) is installed into PYTHON_INSTALL_DIR and lib. This is a regression from foxy to humble. In the past, only .py files were copied, now we copy over the complete directory, which happens to also have the above library in it.

Since I do not know better, I exclude libraries from being copied.

See: https://github.com/ros2/rosidl_python/issues/186

Signed-off-by: Matthias Schoepfer <m.schoepfer@rethinkrobotics.com>