### PR TITLE
Deprecate ament_cmake_nose

### DIFF
--- a/ament_cmake_nose/ament_cmake_nose-extras.cmake
+++ b/ament_cmake_nose/ament_cmake_nose-extras.cmake
@@ -59,3 +59,8 @@ endmacro()
 
 include("${ament_cmake_nose_DIR}/ament_add_nose_test.cmake")
 include("${ament_cmake_nose_DIR}/ament_find_nosetests.cmake")
+
+message(WARNING
+  "Following guidance from the upstream nose maintainers, this package is "
+  "deprecated and will be removed. Users are encouraged to switch to "
+  "ament_cmake_pytest.")

--- a/ament_cmake_nose/package.xml
+++ b/ament_cmake_nose/package.xml
@@ -20,5 +20,10 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <deprecated>
+      Following guidance from the upstream nose maintainers, this package is
+      deprecated and will be removed. Users are encouraged to switch to
+      ament_cmake_pytest.
+    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
Upstream documentation: https://nose.readthedocs.io/en/latest/#note-to-users

Closes #414