### PR TITLE
Use file(GENERATE OUTPUT) to create package.dsv

### DIFF
--- a/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
@@ -83,7 +83,7 @@ function(ament_environment_hooks)
     if(DEFINED AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename})
       # write .dsv file containing the descriptor of the environment hook
       set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/${hook_basename}.dsv")
-      file(WRITE "${dsv_file}" "${AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename}}\n")
+      file(GENERATE OUTPUT "${dsv_file}" CONTENT "${AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename}}\n")
       install(
         FILES "${dsv_file}"
         DESTINATION "share/${PROJECT_NAME}/environment"

--- a/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
@@ -103,7 +103,7 @@ function(ament_generate_package_environment)
   endif()
   list(APPEND all_package_level_extensions "dsv")
   set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/local_setup.dsv")
-  file(WRITE "${dsv_file}" "${all_hooks}")
+  file(GENERATE OUTPUT "${dsv_file}" CONTENT "${all_hooks}")
   install(
     FILES "${dsv_file}"
     DESTINATION "share/${PROJECT_NAME}"
@@ -112,10 +112,11 @@ function(ament_generate_package_environment)
   # generate package.dsv file
   list(SORT all_package_level_extensions)
   set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/package.dsv")
-  file(WRITE "${dsv_file}" "")
+  set(dsv_content "")
   foreach(ext ${all_package_level_extensions})
-    file(APPEND "${dsv_file}" "source;share/${PROJECT_NAME}/local_setup.${ext}\n")
+    set(dsv_content "${dsv_content}source;share/${PROJECT_NAME}/local_setup.${ext}\n")
   endforeach()
+  file(GENERATE OUTPUT "${dsv_file}" CONTENT "${dsv_content}")
   install(
     FILES "${dsv_file}"
     DESTINATION "share/${PROJECT_NAME}"


### PR DESCRIPTION
Using `file(WRITE)` and `file(APPEND)` causes the modification stamp of the file to be changed each time CMake configures, resulting in an 'Installing' message rather than an 'Up-to-date' message even though the file content is identical.

Using `file(GENERATE OUTPUT)` updates the timestamp of the file only if the content changes.