### PR TITLE
Error when trying to symlink install an INTERFACE_LIBRARY

### DIFF
--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake
@@ -77,6 +77,12 @@ function(ament_cmake_symlink_install_targets)
       if(WIN32 AND "${target_type}" STREQUAL "SHARED_LIBRARY")
         list(APPEND target_files "$<TARGET_LINKER_FILE:${target}>")
       endif()
+      if("${target_type}" STREQUAL "INTERFACE_LIBRARY")
+        message(FATAL_ERROR
+          "ament_cmake_symlink_install_targets() '${target}' is an interface "
+          "library - there's nothing to symlink install. Perhaps you forgot "
+          "to add EXPORT or INCLUDES DESTINATION?")
+      endif()
     endforeach()
 
     string(REPLACE ";" "\" \"" target_files_quoted


### PR DESCRIPTION
Resolves ament/ament_cmake#412

There's nothing to install, so the generator expression `$<TARGET_FILE:"${target}">` will raise an error. Instead of changing that behavior this outputs a more helpful error message instead.

When not using `--symlink-install` CMake seems to do nothing in this case, so an alternative fix would be to pass the arguments to `_install()` as is done for other unsupported keyword arguments. However I didn't implement that because if there are other targets in the same `install(TARGETS ...)` command then they will be copied instead of symlinked.