### PR TITLE
Support INTERFACE on ament_auto_add_library

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -67,24 +67,26 @@ macro(ament_auto_add_library target)
 
   # add include directory of this package if it exists
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    if (ARG_INTERFACE)
+    if(ARG_INTERFACE)
       target_include_directories("${target}" INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>)
+        "${CMAKE_CURRENT_SOURCE_DIR}/include")
     else()
       target_include_directories("${target}" PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>)
+        "${CMAKE_CURRENT_SOURCE_DIR}/include")
     endif()
   endif()
   # link against other libraries of this package
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
       NOT ARG_NO_TARGET_LINK_LIBRARIES)
-    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+    if(ARG_INTERFACE)
+      target_link_libraries("${target}" INTERFACE ${${PROJECT_NAME}_LIBRARIES})
+    else()
+      target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+    endif()
   endif()
 
   # add exported information from found build dependencies
-  if (ARG_INTERFACE)
+  if(ARG_INTERFACE)
     ament_target_dependencies(${target} INTERFACE ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
   else()
     ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -67,29 +67,15 @@ macro(ament_auto_package)
 
   # export and install all libraries
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
-    if(NOT ${${PROJECT_NAME}_LIBRARIES} STREQUAL "")
-      get_target_property(target_type ${${PROJECT_NAME}_LIBRARIES} TYPE)
-    endif()
-    # check if the target is an INTERFACE library
-    if ("${target_type}" STREQUAL "INTERFACE_LIBRARY")
-      ament_export_targets(export_${${PROJECT_NAME}_LIBRARIES} HAS_LIBRARY_TARGET)
-      install(
-        TARGETS ${${PROJECT_NAME}_LIBRARIES}
-        EXPORT export_${${PROJECT_NAME}_LIBRARIES}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
-      )
-    else()
-      ament_export_libraries(${${PROJECT_NAME}_LIBRARIES})
-      install(
-        TARGETS ${${PROJECT_NAME}_LIBRARIES}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
-      )
-    endif()
+    ament_export_targets(export_${${PROJECT_NAME}_LIBRARIES} HAS_LIBRARY_TARGET)
+    install(
+      TARGETS ${${PROJECT_NAME}_LIBRARIES}
+      EXPORT export_${${PROJECT_NAME}_LIBRARIES}
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+      INCLUDES DESTINATION include
+    )
   endif()
 
   # install all executables

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -67,13 +67,29 @@ macro(ament_auto_package)
 
   # export and install all libraries
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
-    ament_export_libraries(${${PROJECT_NAME}_LIBRARIES})
-    install(
-      TARGETS ${${PROJECT_NAME}_LIBRARIES}
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib
-      RUNTIME DESTINATION bin
-    )
+    if(NOT ${${PROJECT_NAME}_LIBRARIES} STREQUAL "")
+      get_target_property(target_type ${${PROJECT_NAME}_LIBRARIES} TYPE)
+    endif()
+    # check if the target is an INTERFACE library
+    if ("${target_type}" STREQUAL "INTERFACE_LIBRARY")
+      ament_export_targets(export_${${PROJECT_NAME}_LIBRARIES} HAS_LIBRARY_TARGET)
+      install(
+        TARGETS ${${PROJECT_NAME}_LIBRARIES}
+        EXPORT export_${${PROJECT_NAME}_LIBRARIES}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
+      )
+    else()
+      ament_export_libraries(${${PROJECT_NAME}_LIBRARIES})
+      install(
+        TARGETS ${${PROJECT_NAME}_LIBRARIES}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+      )
+    endif()
   endif()
 
   # install all executables

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -67,10 +67,10 @@ macro(ament_auto_package)
 
   # export and install all libraries
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
-    ament_export_targets(export_${${PROJECT_NAME}_LIBRARIES} HAS_LIBRARY_TARGET)
+    ament_export_targets(export_${PROJECT_NAME}_LIBRARIES HAS_LIBRARY_TARGET)
     install(
       TARGETS ${${PROJECT_NAME}_LIBRARIES}
-      EXPORT export_${${PROJECT_NAME}_LIBRARIES}
+      EXPORT export_${PROJECT_NAME}_LIBRARIES
       ARCHIVE DESTINATION lib
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -67,14 +67,20 @@ macro(ament_auto_package)
 
   # export and install all libraries
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
-    ament_export_targets(export_${PROJECT_NAME}_LIBRARIES HAS_LIBRARY_TARGET)
+    set(without_interfaces "")
+    foreach(library_name ${${PROJECT_NAME}_LIBRARIES})
+      get_target_property(library_type ${library_name} TYPE)
+      if(NOT "${library_type}" STREQUAL "INTERFACE_LIBRARY")
+        list(APPEND without_interfaces ${library_name})
+      endif()
+    endforeach()
+
+    ament_export_libraries(${without_interfaces})
     install(
-      TARGETS ${${PROJECT_NAME}_LIBRARIES}
-      EXPORT export_${PROJECT_NAME}_LIBRARIES
+      TARGETS ${without_interfaces}
       ARCHIVE DESTINATION lib
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin
-      INCLUDES DESTINATION include
     )
   endif()
 


### PR DESCRIPTION
This feature makes it easier to create ament packages from header-only libraries.

Example:
```cmake
cmake_minimum_required(VERSION 3.5)
project(headeronlylib)

# find dependencies
find_package(ament_cmake_auto REQUIRED)
ament_auto_find_build_dependencies()

# create library
ament_auto_add_library(${PROJECT_NAME} INTERFACE)

ament_auto_package()
```