### PR TITLE
Support Debian-specific install dir for ament_cmake_python

### DIFF
--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -43,12 +43,18 @@ endmacro()
 macro(_ament_cmake_python_get_python_install_dir)
   if(NOT DEFINED PYTHON_INSTALL_DIR)
     # avoid storing backslash in cached variable since CMake will interpret it as escape character
+    # This auto detection code uses the same logic as get_python_install_path() in colcon-core
     set(_python_code
-      "import os"
-      "import sysconfig"
-      "get_default_scheme = sysconfig.get_default_scheme if hasattr(sysconfig, 'get_default_scheme') else sysconfig._get_default_scheme"
-      "scheme = 'deb_system' if 'deb_system' in sysconfig.get_scheme_names() else get_default_scheme()"
-      "print(os.path.relpath(sysconfig.get_path('purelib', scheme=scheme, vars={'base': '${CMAKE_INSTALL_PREFIX}'}), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
+      "\
+import os
+import sysconfig
+schemes = sysconfig.get_scheme_names()
+kwargs = {'vars': {'base': '${CMAKE_INSTALL_PREFIX}'}}
+if 'deb_system' in schemes or 'osx_framework_library' in schemes:
+    kwargs['scheme'] = 'posix_prefix'
+elif 'rpm_prefix' in schemes:
+    kwargs['scheme'] = 'rpm_prefix'
+print(os.path.relpath(sysconfig.get_path('purelib', **kwargs), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
     )
     get_executable_path(_python_interpreter Python3::Interpreter CONFIGURE)
     execute_process(


### PR DESCRIPTION
Debian recently added a new default scheme `posix_local` for Python installations, which hardcodes `/usr/local` and ignores the `base` variable, thereby breaking the `PYTHON_INSTALL_DIR` discovery in `ament_cmake_python`.

This PR will explicitly use the `deb_system` scheme if available (which matches the old behavior on Debian and Ubuntu) and fall back to the default scheme for other OS.
