### PR TITLE
ament_cmake_uninstall_target: Correct location of install_manifest.txt

### DIFF
--- a/ament_cmake_core/cmake/uninstall_target/ament_cmake_uninstall_target.cmake.in
+++ b/ament_cmake_core/cmake/uninstall_target/ament_cmake_uninstall_target.cmake.in
@@ -29,7 +29,7 @@ function(ament_cmake_uninstall_target_remove_empty_directories path)
 endfunction()
 
 # uninstall files installed using the standard install() function
-set(install_manifest "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+set(install_manifest "@CMAKE_BINARY_DIR@/install_manifest.txt")
 if(NOT EXISTS "${install_manifest}")
   message(FATAL_ERROR "Cannot find install manifest: ${install_manifest}")
 endif()


### PR DESCRIPTION
The `install_manifest.txt` is never placed in `CMAKE_CURRENT_BINARY_DIR` (i.e. the build directory corresponding to the source directory in which this code is included), but always in CMAKE_BINARY_DIR (i.e. the root of the build directory). See https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake for the official documentation of CMake on how to define an uninstall target.

This fixes the execution of the `uninstall` target when `find_package(ament_cmake_core)` is called in a `CMakeLists.txt` contained in a directory different from the root of source, see https://github.com/ament/ament_cmake/issues/427 .