### PR TITLE
ament_cmake_pytest needs a build_depend on ament_cmake_test.

### DIFF
--- a/ament_cmake_pytest/package.xml
+++ b/ament_cmake_pytest/package.xml
@@ -18,6 +18,8 @@
   <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
   <buildtool_export_depend>python3-pytest</buildtool_export_depend>
 
+  <build_depend>ament_cmake_test</build_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ament_cmake_pytest/package.xml
+++ b/ament_cmake_pytest/package.xml
@@ -13,12 +13,11 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_test</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
   <buildtool_export_depend>python3-pytest</buildtool_export_depend>
-
-  <build_depend>ament_cmake_test</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This is so it can find and run the tests.