### PR TITLE
feat(ament_auto_find_build_dependencies): remove duplicate elements from found paths/libraries for performance

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake
@@ -65,12 +65,17 @@ macro(ament_auto_find_build_dependencies)
       set(_REQUIRED_KEYWORD "REQUIRED")
     endif()
     find_package(${_dep} QUIET ${_REQUIRED_KEYWORD})
+    # TODO: if(${_dep}_FOUND) && ${_dep} not in ${PROJECT_NAME}_FOUND_BUILD_DEPENDS
     if(${_dep}_FOUND)
       list(APPEND ${PROJECT_NAME}_FOUND_BUILD_DEPENDS ${_dep})
 
       list(APPEND ${PROJECT_NAME}_FOUND_DEFINITIONS ${${_dep}_DEFINITIONS})
       list(APPEND ${PROJECT_NAME}_FOUND_INCLUDE_DIRS ${${_dep}_INCLUDE_DIRS})
       list(APPEND ${PROJECT_NAME}_FOUND_LIBRARIES ${${_dep}_LIBRARIES})
+      # remove duplicate elements
+      list(REMOVE_DUPLICATES ${PROJECT_NAME}_FOUND_DEFINITIONS)
+      list(REMOVE_DUPLICATES ${PROJECT_NAME}_FOUND_INCLUDE_DIRS)
+      list(REMOVE_DUPLICATES ${PROJECT_NAME}_FOUND_LIBRARIES)
     endif()
   endforeach()
 


### PR DESCRIPTION
# Description

Repetitive calls to `ament_auto_add_library/executable` slow down CMake process extremely when there are lot of build dependencies defiend in `package.xml`. For example in `Autoware` this package consists of several independent modules like `traffic_light`, `crosswalk`, etc. so one may think about building each module as a shared library or a `pluginlib` component as follows:

```
ament_auto_add_library(traffic_light_module ...)
ament_auto_add_library(crosswalk_module ...)
```

However I found that this style extremely slows down `cmake` process when I `colcon build` this package. This is because the size of these variables increase in every call and iteration over these  variables gets inefficeint.

![todo](write the evidence)

# After this PR

# Related issue

- https://github.com/ament/ament_cmake/issues/442