### PR TITLE
Add support for specifying a patch directory in ament_vendor

### DIFF
--- a/ament_cmake_vendor_package/cmake/ament_vendor.cmake
+++ b/ament_cmake_vendor_package/cmake/ament_vendor.cmake
@@ -30,7 +30,9 @@
 #   code at.
 # :type VCS_VERSION: string
 # :param PATCHES: paths to patch files to apply to downloaded source code,
-#   either absolute or relative to the current calling directory.
+#   either absolute or relative to the current calling directory. If given a
+#   directory, all patch files in the directory (non-recursive) will be applied
+#   in alphabetical order.
 # :type PATCHES: list of strings
 # :param CMAKE_ARGS: extra arguments to pass to the CMake invocation of the
 #   external project.
@@ -153,6 +155,10 @@ function(_ament_vendor TARGET_NAME VCS_TYPE VCS_URL VCS_VERSION PATCHES CMAKE_AR
     endif()
     if(NOT EXISTS ${PATCH})
       message(FATAL_ERROR "ament_vendor() could not find patch file: ${PATCH}")
+    endif()
+    if(IS_DIRECTORY ${PATCH})
+      file(GLOB PATCH LIST_DIRECTORIES FALSE "${PATCH}/*.patch" "${PATCH}/*.diff")
+      list(SORT PATCH)
     endif()
     list(APPEND PATCH_FILES ${PATCH})
   endforeach()


### PR DESCRIPTION
In cases where we have more than one patch for a project, it can be cleaner to put the patches in a subdirectory and apply all of them alphabetically rather than list them explicitly.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18722)](http://ci.ros2.org/job/ci_linux/18722/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13248)](http://ci.ros2.org/job/ci_linux-aarch64/13248/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=19461)](http://ci.ros2.org/job/ci_windows/19461/)