### PR TITLE
feat: support components in ament_export_dependencies

### DIFF
--- a/ament_cmake_export_dependencies/cmake/ament_cmake_export_dependencies-extras.cmake.in
+++ b/ament_cmake_export_dependencies/cmake/ament_cmake_export_dependencies-extras.cmake.in
@@ -17,8 +17,17 @@ if(NOT _exported_dependencies STREQUAL "")
   set(@PROJECT_NAME@_RECURSIVE_DEPENDENCIES ${_exported_dependencies})
   set(_libraries)
   foreach(_dep ${_exported_dependencies})
-    if(NOT ${_dep}_FOUND)
-      find_package("${_dep}" QUIET REQUIRED)
+    # unpack components (if any)
+    string(REGEX REPLACE ":" ";" _unpacked "${_dep}")
+    list(POP_FRONT _unpacked _dep)
+    if(NOT "${_unpacked}" STREQUAL "")
+      # has components
+      find_package("${_dep}" QUIET REQUIRED COMPONENTS "${_unpacked}")
+    else()
+      # no components
+      if(NOT ${_dep}_FOUND)
+        find_package("${_dep}" QUIET REQUIRED)
+      endif()
     endif()
     # if a package provides modern CMake interface targets use them
     # exclusively assuming the classic CMake variables only exist for

--- a/ament_cmake_export_dependencies/cmake/ament_export_dependencies.cmake
+++ b/ament_cmake_export_dependencies/cmake/ament_export_dependencies.cmake
@@ -15,12 +15,18 @@
 #
 # Export dependencies to downstream packages.
 #
+# Behavior depends on whether ``COMPONENTS`` parameter is provided. If provided,
+# ``ament_export_dependencies`` expects a single package name, followed a list
+# of components to export. Otherwise, it expects a list of packages to export.
 # Each package name must be find_package()-able with the exact same case.
 # Additionally the exported variables must have a prefix with the same case
 # and the suffixes must be INCLUDE_DIRS and LIBRARIES.
 #
 # :param ARGN: a list of package names
 # :type ARGN: list of strings
+# :param COMPONENTS: optional list of components. In such cas, only 1 package
+#                    name shall be listed
+# :type COMPONENTS: list of strings
 #
 # @public
 #
@@ -32,12 +38,32 @@ macro(ament_export_dependencies)
 
   if(${ARGC} GREATER 0)
     _ament_cmake_export_dependencies_register_package_hook()
-    foreach(_arg ${ARGN})
-      # only pass package name
-      # will be resolved by downstream packages
-      # must be find_package()-able
-      # and provide _INCLUDE_DIRS and _LIBRARIES
-      list(APPEND _AMENT_CMAKE_EXPORT_DEPENDENCIES "${_arg}")
-    endforeach()
+
+    cmake_parse_arguments(_ARGS "" "" "COMPONENTS" ${ARGN})
+    if(NOT "${_ARGS_COMPONENTS}" STREQUAL "")
+      # parse a single dependency with its components
+      list(LENGTH _ARGS_UNPARSED_ARGUMENTS _unparsed_length)
+      if (NOT ${_unparsed_length} EQUAL "1")
+        message(FATAL_ERROR
+          "ament_export_dependencies() called with unknown arguments: ${ARGN}")
+      endif()
+      # pack the dependency and all its components "dep:compA:compB:compC"
+      # TODO use AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR-like variable instead of hardcoded ":"?
+      set (_unpacked "${_ARGS_UNPARSED_ARGUMENTS}")
+      list(APPEND _unpacked "${_ARGS_COMPONENTS}")
+      string(REGEX REPLACE ";" ":" _packed "${_unpacked}")
+      list(APPEND _AMENT_CMAKE_EXPORT_DEPENDENCIES "${_packed}")
+
+    else()
+      foreach(_arg ${ARGN})
+        # only pass package name
+        # will be resolved by downstream packages
+        # must be find_package()-able
+        # and provide _INCLUDE_DIRS and _LIBRARIES
+        list(APPEND _AMENT_CMAKE_EXPORT_DEPENDENCIES "${_arg}")
+      endforeach()
+
+    endif() 
   endif()
+
 endmacro()


### PR DESCRIPTION
As explained here: https://github.com/ament/ament_cmake/issues/456

# Test

For example, I have replaced all `find_package()` call in the autoware.universe project by the following:

```cmake
macro(ament_auto_find_package package)

  find_package(${package} ${ARGN})

  cmake_parse_arguments(_ARG "QUIET;REQUIRED" "" "COMPONENTS" ${ARGN})
  if(NOT "${_ARG_COMPONENTS}" STREQUAL "")
    ament_export_dependencies(${package} COMPONENTS ${_ARG_COMPONENTS})
  else()
    ament_export_dependencies(${package})
  endif()
endmacro()
``` 

This macro simply make sure that all fetched packages are correctly exported downstream. 

Without this feature, the macro does not care about components. For example `ament_auto_find_package(PCL REQUIRED COMPONENTS common)` would eventually call `ament_export_dependencies(PCL)`, which means downstream packages will fetch all PCL components instead of just `common`. For example, on the package `behavior_path_planner`, cmake execution flame graph looks like this:
![image](https://github.com/ament/ament_cmake/assets/18645627/28f9f0fe-d3ee-487a-9a02-2ecf99cab8b7)

With the feature (e.g. ``ament_export_dependencies(PCL COMPONENTS common)`), it looks like this:
![image](https://github.com/ament/ament_cmake/assets/18645627/3f86b0b4-29ba-487b-ae5c-e47405bdb0c7)

As you can see in the first graph, VTK library is being fetched, although it is never used in the whole project. This is because if you can only do `ament_export_dependencies(PCL)`, then all downstream package will always fetch all PCL components. On the second graph, the VTK library does not appear, because all upstream packages only ever used limited components (`common`, `io`, etc).

