### PR TITLE
Do not export exec_depends in ament_auto_package

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -31,7 +31,7 @@
 # :param ARGN: any other arguments are passed through to ament_package()
 # :type ARGN: list of strings
 #
-# Export all found build dependencies which are also run
+# Export all found build dependencies which are also export
 # dependencies.
 # If the package has an include directory install all recursively
 # found header files (ending in h, hh, hpp, hxx) and export the
@@ -46,15 +46,14 @@ macro(ament_auto_package)
   cmake_parse_arguments(_ARG "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
   # passing all unparsed arguments to ament_package()
 
-  # export all found build dependencies which are also run dependencies
-  set(_run_depends
+  # export all found build dependencies which are also export dependencies
+  set(_export_depends
     ${${PROJECT_NAME}_BUILD_EXPORT_DEPENDS}
     ${${PROJECT_NAME}_BUILDTOOL_EXPORT_DEPENDS}
-    ${${PROJECT_NAME}_EXEC_DEPENDS})
   foreach(_dep
       ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}
       ${${PROJECT_NAME}_FOUND_BUILDTOOL_DEPENDS})
-    if(_dep IN_LIST _run_depends)
+    if(_dep IN_LIST _export_depends)
       ament_export_dependencies("${_dep}")
     endif()
   endforeach()


### PR DESCRIPTION
The current behavior (implemented 9 year ago) treats exec_depends (former run_depends) as build_export_depends, which is not correct and in some cases can even break the build of dependent packages.
The combination of  `build_depend` + `exec_depend` (but no `build_export_depend`) is a common pattern for executables (which do not need to export), whereas libraries (which need to export) often use the blanket `depend`.
