### PR TITLE
ament_cmake_vendor_package: Replace 'git' dep with 'vcstool'

### DIFF
--- a/ament_cmake_vendor_package/package.xml
+++ b/ament_cmake_vendor_package/package.xml
@@ -13,10 +13,10 @@
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
-  <buildtool_export_depend>ament_cmake_export_dependencies</buildtool_export_depend>
 
+  <buildtool_export_depend>ament_cmake_export_dependencies</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
-  <buildtool_export_depend>git</buildtool_export_depend>
+  <buildtool_export_depend>python3-vcstool</buildtool_export_depend>
 
   <test_depend>ament_cmake_test</test_depend>
 


### PR DESCRIPTION
At some point in development, I switched from 'git' to 'vcstool' for fetching sources and forgot to update the manifest.

Should resolve the Rpr failure in ros2/rviz#995.