### PR TITLE
Add ament_auto_add_gmock to ament_cmake_auto

### DIFF
--- a/ament_cmake_auto/CMakeLists.txt
+++ b/ament_cmake_auto/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(ament_cmake_auto NONE)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gmock REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 
 ament_package(

--- a/ament_cmake_auto/ament_cmake_auto-extras.cmake
+++ b/ament_cmake_auto/ament_cmake_auto-extras.cmake
@@ -17,6 +17,7 @@
 find_package(ament_cmake QUIET REQUIRED)
 
 include("${ament_cmake_auto_DIR}/ament_auto_add_executable.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_add_gmock.cmake")
 include("${ament_cmake_auto_DIR}/ament_auto_add_gtest.cmake")
 include("${ament_cmake_auto_DIR}/ament_auto_add_library.cmake")
 include("${ament_cmake_auto_DIR}/ament_auto_generate_code.cmake")

--- a/ament_cmake_auto/cmake/ament_auto_add_gmock.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_gmock.cmake
@@ -1,4 +1,4 @@
-# Copyright 2021 Whitley Software Services, LLC
+# Copyright 2023 PAL Robotics S.L.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_auto/cmake/ament_auto_add_gmock.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_gmock.cmake
@@ -1,0 +1,61 @@
+# Copyright 2021 Whitley Software Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a gmock with all found test dependencies.
+#
+# Call add_gmock(target ARGN), link it against the gmock libraries
+# and all found test dependencies.
+#
+# If gmock is not available the specified target is not being created and
+# therefore the target existence should be checked before being used.
+#
+# :param target: the target name which will also be used as the test name
+# :type target: string
+# :param ARGN: the list of source files and parameters
+# :type ARGN: list of strings
+#
+# @public
+#
+macro(ament_auto_add_gmock target)
+  cmake_parse_arguments(_ARG
+    "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
+    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
+    ${ARGN})
+  if(NOT _ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ament_auto_add_gmock() must be invoked with at least one source file")
+  endif()
+
+  # add gmock
+  ament_add_gmock("${target}" ${ARGN})
+
+  # add include directory of this package if it exists
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_include_directories("${target}" PUBLIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  endif()
+
+  # link against other libraries of this package
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
+    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+  endif()
+
+  # add exported information from found dependencies
+  ament_target_dependencies(${target}
+    ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}
+    ${${PROJECT_NAME}_FOUND_TEST_DEPENDS}
+  )
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_add_gmock.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_gmock.cmake
@@ -39,6 +39,8 @@ macro(ament_auto_add_gmock target)
       "ament_auto_add_gmock() must be invoked with at least one source file")
   endif()
 
+  find_package(ament_cmake_gmock QUIET REQUIRED)
+
   # add gmock
   ament_add_gmock("${target}" ${ARGN})
 

--- a/ament_cmake_auto/cmake/ament_auto_add_gtest.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_gtest.cmake
@@ -61,6 +61,8 @@ macro(ament_auto_add_gtest target)
       "ament_auto_add_gtest() must be invoked with at least one source file")
   endif()
 
+  find_package(ament_cmake_gtest QUIET REQUIRED)
+
   # add executable
   set(_arg_executable ${_ARG_UNPARSED_ARGUMENTS})
   if(_ARG_SKIP_LINKING_MAIN_LIBRARIES)

--- a/ament_cmake_auto/package.xml
+++ b/ament_cmake_auto/package.xml
@@ -13,8 +13,10 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_gmock</buildtool_depend>
   <buildtool_depend>ament_cmake_gtest</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_gmock</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_gtest</buildtool_export_depend>
 
   <export>


### PR DESCRIPTION
`ament_auto_add_gtest` offers convenient macros for adding gtests.

This PR extends `ament_cmake_auto` to also offer support for gmock tests.

Fixes #483.