### PR TITLE
Fix CMake error when entire ament projects are added via add_subdirectory

### DIFF
--- a/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
@@ -82,7 +82,7 @@ function(ament_environment_hooks)
     get_filename_component(hook_basename "${hook}" NAME_WE)
     if(DEFINED AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename})
       # write .dsv file containing the descriptor of the environment hook
-      set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/${hook_basename}.dsv")
+      set(dsv_file "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment_hooks/${hook_basename}.dsv")
       file(GENERATE OUTPUT "${dsv_file}" CONTENT "${AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename}}\n")
       install(
         FILES "${dsv_file}"

--- a/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_generate_package_environment.cmake
@@ -102,7 +102,7 @@ function(ament_generate_package_environment)
     endforeach()
   endif()
   list(APPEND all_package_level_extensions "dsv")
-  set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/local_setup.dsv")
+  set(dsv_file "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment_hooks/local_setup.dsv")
   file(GENERATE OUTPUT "${dsv_file}" CONTENT "${all_hooks}")
   install(
     FILES "${dsv_file}"
@@ -111,7 +111,7 @@ function(ament_generate_package_environment)
 
   # generate package.dsv file
   list(SORT all_package_level_extensions)
-  set(dsv_file "${CMAKE_BINARY_DIR}/ament_cmake_environment_hooks/package.dsv")
+  set(dsv_file "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment_hooks/package.dsv")
   set(dsv_content "")
   foreach(ext ${all_package_level_extensions})
     set(dsv_content "${dsv_content}source;share/${PROJECT_NAME}/local_setup.${ext}\n")


### PR DESCRIPTION
In https://github.com/robotology/yarp-devices-ros2/issues/61 we have a CMake project that includes two CMake ament projects via `add_subdirectory`. 

In ROS 2 Iron it fails with:
~~~
CMake Error: Files to be generated by multiple different commands: "/home/user/yarp-devices-ros2/build/ament_cmake_environment_hooks/ament_prefix_path.dsv"
CMake Error: Files to be generated by multiple different commands: "/home/user/yarp-devices-ros2/build/ament_cmake_environment_hooks/library_path.dsv"
~~~

while in ROS 2 Humble the configuration ended with a success (even if everything worked in our specific case only because the files were identical in the two projects, as the files were effectively overwritten by the `configure_call`).

This PR fixes this problem by ensuring that temporary dsv files are generated in `CMAKE_CURRENT_BINARY_DIR` (i.e. a build directory specific to each ament project) instead of `CMAKE_BINARY_DIR` (the top build directory, common to all CMake projects included via `add_subdirectory`).

Note that I read @cottsay's comment in https://github.com/ament/ament_cmake/pull/416#issuecomment-1379685273 . However, after reading https://github.com/ros2/ros2_documentation/pull/934 and https://github.com/ament/ament_cmake/issues/227, I think the issue is when `ament_package` and `ament_export_include_directories` are in two different directories, and at least if you only care about modern CMake targets, everything should work fine if both `ament_package` and `ament_export_include_directories` are in the same subdirectory. Indeed, adding entire projects via `add_subdirectory` is a common workflow in modern CMake (for example when using `FetchContent` module, see for example https://www.youtube.com/watch?v=bsXLMQ6WgIk&t=3126s).