### PR TITLE
Use CMAKE_CURRENT_BINARY_DIR instead of CMAKE_BINARY_DIR  in ament_generate_environment

### DIFF
--- a/ament_cmake_core/cmake/environment/ament_generate_environment.cmake
+++ b/ament_cmake_core/cmake/environment/ament_generate_environment.cmake
@@ -44,10 +44,10 @@ function(ament_generate_environment)
       get_filename_component(name "${name}" NAME)
       configure_file(
         "${file}"
-        "${CMAKE_BINARY_DIR}/ament_cmake_environment/${name}"
+        "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment/${name}"
         @ONLY
       )
-      set(file "${CMAKE_BINARY_DIR}/ament_cmake_environment/${name}")
+      set(file "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment/${name}")
     endif()
 
     install(


### PR DESCRIPTION
I did not noticed this while working on https://github.com/ament/ament_cmake/pull/484 as it was not migrated to use `file(GENERATE [..])` in https://github.com/ament/ament_cmake/pull/416, so it does not result in an error in the `add_subdirectory` case described in https://github.com/ament/ament_cmake/pull/484 . However, to avoid cross-talking between different packages, it make sense to use `CMAKE_CURRENT_BINARY_DIR` also in this context.