### PR TITLE
Improve Python install path detection

### DIFF
--- a/ament_cmake_python/ament_cmake_python-extras.cmake
+++ b/ament_cmake_python/ament_cmake_python-extras.cmake
@@ -48,12 +48,13 @@ macro(_ament_cmake_python_get_python_install_dir)
       "\
 import os
 import sysconfig
-schemes = sysconfig.get_scheme_names()
 kwargs = {'vars': {'base': '${CMAKE_INSTALL_PREFIX}'}}
-if 'deb_system' in schemes or 'osx_framework_library' in schemes:
-    kwargs['scheme'] = 'posix_prefix'
-elif 'rpm_prefix' in schemes:
-    kwargs['scheme'] = 'rpm_prefix'
+if sysconfig.get_config_var('base') != os.path.normpath('${CMAKE_INSTALL_PREFIX}'):
+    schemes = sysconfig.get_scheme_names()
+    if 'deb_system' in schemes or 'osx_framework_library' in schemes:
+        kwargs['scheme'] = 'posix_prefix'
+    elif 'rpm_prefix' in schemes:
+        kwargs['scheme'] = 'rpm_prefix'
 print(os.path.relpath(sysconfig.get_path('purelib', **kwargs), start='${CMAKE_INSTALL_PREFIX}').replace(os.sep, '/'))"
     )
     get_executable_path(_python_interpreter Python3::Interpreter CONFIGURE)


### PR DESCRIPTION
[ This is the companion PR to colcon/colcon-core/pull/601 ]

This PR makes the customized Python path scheme logic in `ament_cmake_python` contingent on an install prefix other than `/usr`.

This makes ament more distribution-friendly and prevents the accidental overwriting of system packages in case someone decides to install their Python packages to `/usr`. There is no other change in behavior.