### PR TITLE
Add NAMESPACE support to ament_export_targets

### DIFF
--- a/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
+++ b/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
@@ -25,7 +25,6 @@ list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS "${_generated_extra_file}")
 # install export files for targets
 if(NOT _AMENT_CMAKE_EXPORT_TARGETS STREQUAL "")
   foreach(_target ${_AMENT_CMAKE_EXPORT_TARGETS})
-
     install(
       EXPORT "${_target}"
       DESTINATION share/${PROJECT_NAME}/cmake

--- a/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
+++ b/ament_cmake_export_targets/cmake/ament_cmake_export_targets_package_hook.cmake
@@ -25,10 +25,11 @@ list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS "${_generated_extra_file}")
 # install export files for targets
 if(NOT _AMENT_CMAKE_EXPORT_TARGETS STREQUAL "")
   foreach(_target ${_AMENT_CMAKE_EXPORT_TARGETS})
+
     install(
       EXPORT "${_target}"
       DESTINATION share/${PROJECT_NAME}/cmake
-      NAMESPACE "${PROJECT_NAME}::"
+      NAMESPACE "${_AMENT_CMAKE_EXPORT_TARGETS_NAMESPACE}"
       FILE "${_target}Export.cmake"
     )
   endforeach()

--- a/ament_cmake_export_targets/cmake/ament_export_targets.cmake
+++ b/ament_cmake_export_targets/cmake/ament_export_targets.cmake
@@ -22,10 +22,11 @@
 # :param HAS_LIBRARY_TARGET: if set, an environment variable will be defined
 #   so that the library can be found at runtime
 # :type HAS_LIBRARY_TARGET: option
-# :param NAMESPACE: the exported namespace for the target if set. 
+# :keyword NAMESPACE: the exported namespace for the target if set. 
 #    The default is the value of ``${PROJECT_NAME}::``.
-# TODO not sure what to set for type and whatnot
-# :type NAMESPACE: option
+#    This is an advanced option. It should be used carefully and clearly documented
+#    in a usage guide for any package that makes use of this option.
+# :type NAMESPACE: string
 # :param ARGN: a list of export names
 # :type ARGN: list of strings
 #

--- a/ament_cmake_export_targets/cmake/ament_export_targets.cmake
+++ b/ament_cmake_export_targets/cmake/ament_export_targets.cmake
@@ -16,12 +16,16 @@
 # Export targets to downstream packages.
 #
 # Each export name must have been used to install targets using
-# ``install(TARGETS ... EXPORT name ...)``.
+# ``install(TARGETS ... EXPORT name NAMESPACE my_namespace ...)``.
 # The ``install(EXPORT ...)`` invocation is handled by this macros.
 #
 # :param HAS_LIBRARY_TARGET: if set, an environment variable will be defined
 #   so that the library can be found at runtime
 # :type HAS_LIBRARY_TARGET: option
+# :param NAMESPACE: the exported namespace for the target if set. 
+#    The default is the value of ``${PROJECT_NAME}::``.
+# TODO not sure what to set for type and whatnot
+# :type NAMESPACE: option
 # :param ARGN: a list of export names
 # :type ARGN: list of strings
 #
@@ -32,13 +36,20 @@ macro(ament_export_targets)
     message(FATAL_ERROR
       "ament_export_targets() must be called before ament_package()")
   endif()
-  cmake_parse_arguments(_ARG "HAS_LIBRARY_TARGET" "" "" ${ARGN})
+  cmake_parse_arguments(_ARG "HAS_LIBRARY_TARGET" "NAMESPACE" "" ${ARGN})
 
   if(${ARGC} GREATER 0)
     _ament_cmake_export_targets_register_package_hook()
     foreach(_arg ${_ARG_UNPARSED_ARGUMENTS})
       list(APPEND _AMENT_CMAKE_EXPORT_TARGETS "${_arg}")
     endforeach()
+
+    set(_AMENT_CMAKE_EXPORT_TARGETS_NAMESPACE ${_ARG_NAMESPACE})
+
+    # Allow optionally overriding default namespace
+    if(NOT DEFINED _AMENT_CMAKE_EXPORT_TARGETS_NAMESPACE)
+      set(_AMENT_CMAKE_EXPORT_TARGETS_NAMESPACE "${PROJECT_NAME}::")
+    endif()
 
     # if the export name contains is a library target
     # make sure to register an environment hook


### PR DESCRIPTION
# Purpose

I want to export targets with ament but under a custom namespace. Currently, it's hard coded to be the project name. The intent is to make this backwards compatible with humble, and obvious to people who have used CMake `install(EXPORT ... NAMESPACE foo)` that it does the same thing.

# Motivation

https://github.com/ament/ament_cmake/issues/292#issuecomment-1901250532
https://github.com/BehaviorTree/BehaviorTree.CPP/issues/751#issuecomment-1901253719

# Example usage in BehaviorTreeCPP

**Top level CMakeLists.txt**
```cmake
INSTALL(TARGETS ${BTCPP_LIBRARY}
    EXPORT ${PROJECT_NAME}Targets
    ARCHIVE DESTINATION ${BTCPP_LIB_DESTINATION}
    LIBRARY DESTINATION ${BTCPP_LIB_DESTINATION}
    RUNTIME DESTINATION ${BTCPP_BIN_DESTINATION}
    INCLUDES DESTINATION ${BTCPP_INCLUDE_DESTINATION}
    )

INSTALL( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
    DESTINATION ${BTCPP_INCLUDE_DESTINATION}
    FILES_MATCHING PATTERN "*.h*")

export_btcpp_package()
```

**ament_build.cmake**
```cmake
macro(export_btcpp_package)
    ament_export_targets(
        ${PROJECT_NAME}Targets
        NAMESPACE BT::
        HAS_LIBRARY_TARGET
    )
    ament_export_dependencies(ament_index_cpp)
    ament_package()
endmacro()
```

Then, to use the library, whether you consume it build with ament or conan enabled, you can always call either of the two.

**using ament_target_dependencies** - sadly this exposes the BTCPP to the public interface even if it's an implementation detail. This only matters if you are building a re-usable library and don't want your consumers know you use BTCPP.
```cmake
cmake_minimum_required(VERSION 3.22.1) # version on Ubuntu Jammy
project(btcpp_ament_tgt_dep LANGUAGES CXX)


set(CMAKE_CXX_STANDARD 17)
set(CMAKE_CXX_STANDARD_REQUIRED ON)

find_package(ament_cmake 1 CONFIG REQUIRED)
find_package(behaviortree_cpp 4 REQUIRED)

add_executable(btcpp_sample main.cpp)


# This function doesn't yet support PRIVATE as an argument.
# See https://github.com/ament/ament_cmake/issues/158#issuecomment-475384147
# Instead, test preserving legacy usage with no linkage specifier.
ament_target_dependencies(btcpp_sample behaviortree_cpp)
```
OR , the preferred approach:
```cmake
cmake_minimum_required(VERSION 3.22.1) # version on Ubuntu Jammy
project(btcpp_tgt_link_libs LANGUAGES CXX)


set(CMAKE_CXX_STANDARD 17)
set(CMAKE_CXX_STANDARD_REQUIRED ON)

find_package(ament_cmake 1 CONFIG REQUIRED)
find_package(behaviortree_cpp 4 CONFIG REQUIRED)

add_executable(btcpp_sample main.cpp)

# Check it works with the same target that conan users use
target_link_libraries(btcpp_sample PRIVATE BT::behaviortree_cpp)
```

Feel free to take a look at the full branch here: https://github.com/Ryanf55/BehaviorTree.CPP/tree/751-use-ament-export-targets

## Assumptions

* All targets and executables installed will have the same namespace
* Must preserve existing behavior by default

## Risks

There's this assumption the target name would never have colons, however it doesn't seem to have any ill effect
```
list(APPEND _IMPORT_CHECK_FILES_FOR_BT::behaviortree_cpp "${_IMPORT_PREFIX}/lib/libbehaviortree_cpp.so" )
```
https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#variables
```
Variable names are case-sensitive and may consist of almost any text, but we recommend sticking to names consisting only of alphanumeric characters plus _ and -.
```
