### PR TITLE
Added a new cmake flag to enable isolation

### DIFF
--- a/ament_cmake_test/cmake/ament_add_test.cmake
+++ b/ament_cmake_test/cmake/ament_add_test.cmake
@@ -56,7 +56,7 @@ function(ament_add_test testname)
   cmake_parse_arguments(ARG
     "GENERATE_RESULT_FOR_RETURN_CODE_ZERO;SKIP_TEST"
     "OUTPUT_FILE;RESULT_FILE;RUNNER;SKIP_RETURN_CODE;TIMEOUT;WORKING_DIRECTORY"
-    "APPEND_ENV;APPEND_LIBRARY_DIRS;COMMAND;ENV"
+    "APPEND_ENV;APPEND_LIBRARY_DIRS;COMMAND;ENV;ISOLATE_TEST"
     ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_add_test() called with unused arguments: "
@@ -84,8 +84,13 @@ function(ament_add_test testname)
   endif()
 
   get_executable_path(python_interpreter Python3::Interpreter BUILD)
+  if(ISOLATE_TEST AND UNIX)
+    set(isolate_test_prefix "{python_interpreter}" "-m" "linux_isolate_process")
+  else()
+    set(isolate_test_prefix "")
+  endif()
   # wrap command with run_test script to ensure test result generation
-  set(cmd_wrapper "${python_interpreter}" "-u" "${ARG_RUNNER}"
+  set(cmd_wrapper "${isolate_test_prefix}" "${python_interpreter}" "-u" "${ARG_RUNNER}"
     "${ARG_RESULT_FILE}"
     "--package-name" "${PROJECT_NAME}")
   if(ARG_SKIP_TEST)

--- a/ament_cmake_test/package.xml
+++ b/ament_cmake_test/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>linux_isolate_process</buildtool_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This adds a new cmake argument called "ISOLATE_TEST" to use https://github.com/adityapande-1995/linux_isolate_process for isolating a test. This would mean more tests can be run in parallel, and can speed up CI. Due to the underlying implementation using the ``unshare`` system call, this can only be used in linux.

The proposal is to add ``linux_isoalte_process`` as a dependency of ament_cmake_test, so that downstream packages get it for free, and hopefully add linux_isoalte_process as a core package in ROS 2.
