### PR TITLE
When finding Python3, use python3 executable as a hint

### DIFF
--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -18,5 +18,8 @@
 #   find_package(Python3 3.8 REQUIRED)
 #   find_package(ament_cmake REQUIRED)
 if(NOT TARGET Python3::Interpreter)
+  if(NOT Python3_EXECUTABLE)
+    find_program(Python3_EXECUTABLE python3)
+  endif()
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 endif()

--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -18,7 +18,16 @@
 #   find_package(Python3 3.8 REQUIRED)
 #   find_package(ament_cmake REQUIRED)
 if(NOT TARGET Python3::Interpreter)
-  if(NOT Python3_EXECUTABLE)
+  # We expect that Python dependencies are met for whatever Python interpreter
+  # is invoked by the "python3" executable, however this may not be the latest
+  # Python version installed on the system. The default behavior of
+  # find_package(Python3) would be to use the latest version, so we
+  # specifically look for a "python3" executable and if found, instruct
+  # find_package(Python3) to use that.
+  # On Windows, the find_package(Python3) logic is different and doesn't
+  # appear to prefer specific versions (i.e. python3.12) over plain
+  # "python.exe" so this extra logic is unnecessary there.
+  if(NOT WIN32 AND NOT Python3_EXECUTABLE)
     find_program(Python3_EXECUTABLE python3)
   endif()
   find_package(Python3 REQUIRED COMPONENTS Interpreter)

--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -21,7 +21,7 @@ if(NOT TARGET Python3::Interpreter)
   # We expect that Python dependencies are met for whatever Python interpreter
   # is invoked by the "python3" executable, however this may not be the latest
   # Python version installed on the system. The default behavior of
-  # find_package(Python3) would be to use the latest version, so we
+  # find_package(Python3) is to use the latest version (i.e. python3.12), so we
   # specifically look for a "python3" executable and if found, instruct
   # find_package(Python3) to use that.
   # On Windows, the find_package(Python3) logic is different and doesn't

--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -21,11 +21,11 @@ if(NOT TARGET Python3::Interpreter)
   # We expect that Python dependencies are met for whatever Python interpreter
   # is invoked by the "python3" executable, however this may not be the latest
   # Python version installed on the system. The default behavior of
-  # find_package(Python3) is to use the latest version (i.e. python3.12), so we
+  # find_package(Python3) is to use the latest version (e.x. python3.12), so we
   # specifically look for a "python3" executable and if found, instruct
   # find_package(Python3) to use that.
   # On Windows, the find_package(Python3) logic is different and doesn't
-  # appear to prefer specific versions (i.e. python3.12) over plain
+  # appear to prefer specific versions (e.x. python3.12) over plain
   # "python.exe" so this extra logic is unnecessary there.
   if(NOT WIN32 AND NOT Python3_EXECUTABLE)
     find_program(Python3_EXECUTABLE python3)


### PR DESCRIPTION
The existing find_package(Python3) call will locate the Python interpreter with the latest version number. However, this may not be the system's default Python interpreter for which our dependencies have been installed.

If Python3_EXECUTABLE is not explicitly specified, use find_program to locate the Python interpreter behind the "python3" command, which is likely the system's default and the one that we want.

If no executable can be found by the name "python3", the find_program call will silently fail and the existing behavior will manifest.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20297)](http://ci.ros2.org/job/ci_linux/20297/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14708)](http://ci.ros2.org/job/ci_linux-aarch64/14708/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=582)](https://ci.ros2.org/job/ci_linux-rhel/582/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21028)](http://ci.ros2.org/job/ci_windows/21028/)
* Windows-debug [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21027)](https://ci.ros2.org/job/ci_windows/21027/) <- did I trigger this wrong? Is it even expected to work?