### PR TITLE
Add design docs for versioning export

### DIFF
--- a/ament_cmake_core/doc/versioning.md
+++ b/ament_cmake_core/doc/versioning.md
@@ -1,0 +1,19 @@
+## Express Version Compatibility in the Installation
+
+Add a COMPATIBILITY argument to `ament_package`. Default to AnyNewerVersion if not supplied which matches current behavior.
+
+User call in `foo's` `CMakeLists.txt`:
+```cmake
+ament_package(COMPATIBILITY SameMajorVersion)
+```
+
+The compatibility would be forwarded to `write_basic_package_version_file`.
+
+Then, you can use it in `bar`
+```cmake
+find_package(foo_core 4 CONFIG REQUIRED)
+```
+
+If you forgot to update `foo_core` from 3 to 4 and rebuild your workspace, then colcon 
+will fail at the configure stage of `bar` with a nice error message.
+

--- a/ament_cmake_export_dependencies/doc/dependency_versioning_export.md
+++ b/ament_cmake_export_dependencies/doc/dependency_versioning_export.md
@@ -1,0 +1,20 @@
+# Express Version Compatibility in Dependencies
+
+`ament_export_dependencies` shall propagate the version requested of dependencies to a call to `find_dependency <version>`.
+
+For example:
+`find_package(foo_core CONFIG 4)` results in
+`add_dependency(foo_core CONFIG 4)`. 
+
+`find_package(foo_core CONFIG 4.8.3-dev2)` results in
+`add_dependency(foo_core CONFIG 4.8.3-dev2)`. 
+
+`find_package(foo_core MODULE)` results in
+`add_dependency(foo_core MODULE)`. 
+
+I think this can be done automatically with the use of `foo_core_FIND_VERSION`.
+
+Adding in the find method of MODULE/CONFIG may be out of scope for this discussion.
+
+I want to avoid a user manually maintaining versions in multiple places.
+It's hard enough as it is to remember when you add a find_package call to also add it to `ament_export_dependencies`.


### PR DESCRIPTION
This adds design docs for how ament packages can express their versioning, and versions of the dependents. It should give nice behavior when making ABI breaking changes if you use Semver.

Please provide feedback. The design docs here explain how it could work.

Copied sections from https://github.com/ament/ament_cmake/issues/506. Read that ticket to get context around the use case and why this is desirable. 
