### PR TITLE
Add some basic tests to ament_cmake_libraries

### DIFF
--- a/ament_cmake_libraries/CMakeLists.txt
+++ b/ament_cmake_libraries/CMakeLists.txt
@@ -8,6 +8,11 @@ ament_package(
   CONFIG_EXTRAS "ament_cmake_libraries-extras.cmake"
 )
 
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
 install(
   DIRECTORY cmake
   DESTINATION share/${PROJECT_NAME}

--- a/ament_cmake_libraries/test/CMakeLists.txt
+++ b/ament_cmake_libraries/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_test(deduplicate "${CMAKE_COMMAND}" -P ${CMAKE_CURRENT_LIST_DIR}/test_deduplicate.cmake)

--- a/ament_cmake_libraries/test/test_deduplicate.cmake
+++ b/ament_cmake_libraries/test/test_deduplicate.cmake
@@ -1,0 +1,31 @@
+include("${CMAKE_CURRENT_LIST_DIR}/utilities.cmake")
+
+# Empty
+set(TEST_IN "")
+ament_libraries_deduplicate(ACTUAL ${TEST_IN})
+assert_equal("" "${ACTUAL}")
+
+# Noop
+set(TEST_IN "foo;bar;baz")
+ament_libraries_deduplicate(ACTUAL ${TEST_IN})
+assert_equal("foo;bar;baz" "${ACTUAL}")
+
+# Simple
+set(TEST_IN "foo;bar;baz;bar")
+ament_libraries_deduplicate(ACTUAL ${TEST_IN})
+assert_equal("foo;baz;bar" "${ACTUAL}")
+
+# With matching build configs
+set(TEST_IN "debug;foo;debug;bar;debug;baz;debug;bar")
+ament_libraries_deduplicate(ACTUAL ${TEST_IN})
+assert_equal("debug;foo;debug;baz;debug;bar" "${ACTUAL}")
+
+# With missing build configs
+set(TEST_IN "debug;foo;debug;bar;debug;baz;bar")
+ament_libraries_deduplicate(ACTUAL ${TEST_IN})
+assert_equal("debug;foo;debug;bar;debug;baz;bar" "${ACTUAL}")
+
+# With mismatched build configs
+set(TEST_IN "debug;foo;debug;bar;debug;baz;release;bar")
+ament_libraries_deduplicate(ACTUAL ${TEST_IN})
+assert_equal("debug;foo;debug;bar;debug;baz;release;bar" "${ACTUAL}")

--- a/ament_cmake_libraries/test/utilities.cmake
+++ b/ament_cmake_libraries/test/utilities.cmake
@@ -1,0 +1,8 @@
+set(ament_cmake_libraries_DIR "${CMAKE_CURRENT_LIST_DIR}/../cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/../ament_cmake_libraries-extras.cmake")
+
+macro(assert_equal EXPECTED ACTUAL)
+  if(NOT "${EXPECTED}" STREQUAL "${ACTUAL}")
+    message(SEND_ERROR "Assert failed: Expected '${EXPECTED}', got '${ACTUAL}'")
+  endif()
+endmacro()


### PR DESCRIPTION
This adds some primitive tests to the `ament_libraries_deduplicate` macro provided by the `ament_cmake_libraries` package.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20379)](http://ci.ros2.org/job/ci_linux/20379/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14788)](http://ci.ros2.org/job/ci_linux-aarch64/14788/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21128)](http://ci.ros2.org/job/ci_windows/21128/)