### PR TITLE
Require CMake 3.12 due to introduction of FindPython3

### DIFF
--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -17,6 +17,10 @@
 # Example:
 #   find_package(Python3 3.8 REQUIRED)
 #   find_package(ament_cmake REQUIRED)
+#
+# FindPython3 is only available in CMake 3.12 or higher,
+# so we need at least that version.
+cmake_minimum_required(VERSION 3.12)
 if(NOT TARGET Python3::Interpreter)
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 endif()


### PR DESCRIPTION
# Purpose

Declare a minimum Python version of 3.12 because FindPython3 is only available in 3.12 or after. This gives better error messages if a user is using too old a version of CMake.

## Before behavior

If you install CMake 3.5, before this PR, you get this error when trying to compile `sensor_msgs` with `colcon`.
```
  Could not find a package configuration file provided by "Python3" with any
  of the following names:

    Python3Config.cmake
    python3-config.cmake

  Add the installation prefix of "Python3" to CMAKE_PREFIX_PATH or set
  "Python3_DIR" to a directory containing one of the above files.  If
  "Python3" provides a separate development package or SDK, be sure it has
  been installed.
  ```
  
## New behavior

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.12 or higher is required.  You are running version 3.5.0

```

## How to prevent things like this in the future?

The CMake maintainers recommend having CI compile at the `cmake_minimum_required` declared in a package.
Thus, all the message packages should be compiled with 3.5. This prevents accidentally adding new CMake features and forgetting to bump `cmake_minimum_required`. 


As far as I can tell, the build farm is using the default CMake version of each Tier 1 platform. I think it would be a lot of customization to get this right. For now, manual tests like this one can catch it.

## References

* https://cmake.org/cmake/help/latest/module/FindPython3.html
* Relates to #513
* #508 sets it to a higher version in rolling, but that can't be backported to `iron` or `humble` because of REP-2000's CMake restrictions.

