### PR TITLE
Subtle fix for ament_libraries_deduplicate tests

### DIFF
--- a/ament_cmake_libraries/test/test_deduplicate.cmake
+++ b/ament_cmake_libraries/test/test_deduplicate.cmake
@@ -26,6 +26,6 @@ ament_libraries_deduplicate(ACTUAL ${TEST_IN})
 assert_equal("debug;foo;debug;bar;debug;baz;bar" "${ACTUAL}")
 
 # With mismatched build configs
-set(TEST_IN "debug;foo;debug;bar;debug;baz;release;bar")
+set(TEST_IN "optimized;foo;optimized;bar;general;baz;general;bar")
 ament_libraries_deduplicate(ACTUAL ${TEST_IN})
-assert_equal("debug;foo;debug;bar;debug;baz;release;bar" "${ACTUAL}")
+assert_equal("optimized;foo;optimized;bar;general;baz;general;bar" "${ACTUAL}")


### PR DESCRIPTION
Evidently 'release' isn't a config keyword, but 'general' is. I also modified the test to assert that the keyword is actually treated like a keyword.

We just got lucky that putting 'release' in that particular spot and treating it like a library name resulted in the same behavior as if it were a build config keyword.