### PR TITLE
More specific prefix in some cmake_parse_argument calls

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -43,7 +43,7 @@
 #
 
 macro(ament_auto_package)
-  cmake_parse_arguments(_ARG "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
+  cmake_parse_arguments(_ARG_AMENT_AUTO_PACKAGE "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
   # passing all unparsed arguments to ament_package()
 
   # export all found build dependencies which are also run dependencies
@@ -86,7 +86,7 @@ macro(ament_auto_package)
 
   # install all executables
   if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
-    if(_ARG_INSTALL_TO_PATH)
+    if(_ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_PATH)
       set(_destination "bin")
     else()
       set(_destination "lib/${PROJECT_NAME}")
@@ -98,7 +98,7 @@ macro(ament_auto_package)
   endif()
 
   # install directories to share
-  foreach(_dir ${_ARG_INSTALL_TO_SHARE})
+  foreach(_dir ${_ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_SHARE})
     install(
       DIRECTORY "${_dir}"
       DESTINATION "share/${PROJECT_NAME}"
@@ -107,5 +107,5 @@ macro(ament_auto_package)
 
   ament_execute_extensions(ament_auto_package)
 
-  ament_package(${_ARG_UNPARSED_ARGUMENTS})
+  ament_package(${_ARG_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS})
 endmacro()

--- a/ament_cmake_core/cmake/core/ament_execute_extensions.cmake
+++ b/ament_cmake_core/cmake/core/ament_execute_extensions.cmake
@@ -23,10 +23,10 @@
 # @public
 #
 macro(ament_execute_extensions extension_point)
-  cmake_parse_arguments(_ARG "" "" "EXCLUDE" ${ARGN})
-  if(_ARG_UNPARSED_ARGUMENTS)
+  cmake_parse_arguments(_ARG_AMENT_EXECUTE_EXTENSIONS "" "" "EXCLUDE" ${ARGN})
+  if(_ARG_AMENT_EXECUTE_EXTENSIONS_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "ament_execute_extensions() called with "
-      "unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+      "unused arguments: ${_ARG_AMENT_EXECUTE_EXTENSIONS_UNPARSED_ARGUMENTS}")
   endif()
   if(AMENT_EXTENSIONS_${extension_point})
     foreach(_extension ${AMENT_EXTENSIONS_${extension_point}})
@@ -38,7 +38,7 @@ macro(ament_execute_extensions extension_point)
           "name and cmake filename")
       endif()
       list(GET _extension_list 0 _pkg_name)
-      if("${_pkg_name}" IN_LIST _ARG_EXCLUDE)
+      if("${_pkg_name}" IN_LIST _ARG_AMENT_EXECUTE_EXTENSIONS_EXCLUDE)
         continue()
       endif()
       list(GET _extension_list 1 _cmake_filename)


### PR DESCRIPTION
The macro `ament_auto_package` doesn't properly pass on the additional arguments to `ament_package`. The reason is that the call to the macro `ament_execute_extensions` again calls `cmake_parse_arguments` with the same variable prefix, effectively overwriting the original `_ARG_UNPARSED_ARGUMENTS` variable and leaving it empty.

I have found this issue to be present both in galactic (which I'm aware is already EOL) and rolling.

As a fix, I renamed changed the prefix argument for `cmake_parse_arguments` to have unique and non-conflicting variable names in both these macros.
