### PR TITLE
Add ALL target for ament_generate_version_header target.

### DIFF
--- a/ament_cmake_gen_version_h/cmake/ament_generate_version_header.cmake
+++ b/ament_cmake_gen_version_h/cmake/ament_generate_version_header.cmake
@@ -147,7 +147,7 @@ function(ament_generate_version_header target)
       "${SCRIPT_TEMPLATE_FILE}"
     COMMENT "Generating ${ARG_HEADER_PATH}")
 
-  add_custom_target("ament_generate_version_header__${target}"
+  add_custom_target("ament_generate_version_header__${target}" ALL
     DEPENDS "${GENERATED_HEADER_FILE}")
   add_dependencies("${target}" "ament_generate_version_header__${target}")
 


### PR DESCRIPTION
This is necessary when using ament_generate_version_header() with a target that is an INTERFACE library, so that it actually gets built.

This should fix #525 