### PR TITLE
Don't write Python bytecode when invoking pytest

### DIFF
--- a/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
+++ b/ament_cmake_pytest/cmake/ament_add_pytest_test.cmake
@@ -99,6 +99,8 @@ function(ament_add_pytest_test testname path)
     "--junit-prefix=${PROJECT_NAME}"
   )
 
+  set(ARG_ENV PYTHONDONTWRITEBYTECODE=1 ${ARG_ENV})
+
   if(ARG_NOCAPTURE)
     # disable output capturing
     list(APPEND cmd "-s")


### PR DESCRIPTION
This should prevent pytest invocations via ament_add_pytest_test from writing `__pycache__` directories into the package sources.

I'm specifically avoiding bumping `ament_cmake_pytest`'s minimum CMake version to 3.15 by using CMake's `list(PREPEND)` function: https://cmake.org/cmake/help/latest/command/list.html#prepend

See also: colcon/colcon-core#611

https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE