### PR TITLE
Ament_auto_package doesn't pass down unparsed arguments to ament_package

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -43,7 +43,7 @@
 #
 
 macro(ament_auto_package)
-  cmake_parse_arguments(_ARG_AMENT_AUTO_PACKAGE "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
+  cmake_parse_arguments(ARG_AMENT_AUTO_PACKAGE "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
   # passing all unparsed arguments to ament_package()
 
   # export all found build dependencies which are also run dependencies
@@ -86,7 +86,7 @@ macro(ament_auto_package)
 
   # install all executables
   if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
-    if(_ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_PATH)
+    if(ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_PATH)
       set(_destination "bin")
     else()
       set(_destination "lib/${PROJECT_NAME}")
@@ -98,7 +98,7 @@ macro(ament_auto_package)
   endif()
 
   # install directories to share
-  foreach(_dir ${_ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_SHARE})
+  foreach(_dir ${ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_SHARE})
     install(
       DIRECTORY "${_dir}"
       DESTINATION "share/${PROJECT_NAME}"
@@ -107,5 +107,5 @@ macro(ament_auto_package)
 
   ament_execute_extensions(ament_auto_package)
 
-  ament_package(${_ARG_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS})
+  ament_package(${ARG_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS})
 endmacro()


### PR DESCRIPTION
Hi,
While working with custom CMake files, I realized that you can't pass down `CONFIG_EXTRAS` arguments through ament_auto_package so that the function ament_package will process it. 

If you put a debug message inside of the ament_auto_package macro that print `"${_ARG_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS}"`, you will find that it display nothing. I found out that if you remove the underscore from the prefix, it works again. 

---

I made two simple package for demonstrating this bug ([minimal_example_ros.zip](https://github.com/user-attachments/files/15920460/minimal_example_ros.zip)): 
- one provider that expose a cmake function `minimal_function` (which just print a text)
- another one that calls this function.

Without the changes, the output of the command `colcon build --packages-select minimal_cmake_caller minimal_cmake_provider` is:

```
Starting >>> minimal_cmake_provider
Finished <<< minimal_cmake_provider [0.28s]                
Starting >>> minimal_cmake_caller
--- stderr: minimal_cmake_caller                         
CMake Error at CMakeLists.txt:11 (minimal_function):
  Unknown CMake command "minimal_function".


---
Failed   <<< minimal_cmake_caller [0.23s, exited with code 1]

Summary: 1 package finished [0.85s]
  1 package failed: minimal_cmake_caller
  1 package had stderr output: minimal_cmake_caller
```

But with the changes, the output becomes what we expect:

```
Starting >>> minimal_cmake_provider
Finished <<< minimal_cmake_provider [0.29s]                
Starting >>> minimal_cmake_caller
--- stderr: minimal_cmake_caller                         
Hey, I'm a function!
---
Finished <<< minimal_cmake_caller [0.27s]

Summary: 2 packages finished [0.79s]
  1 package had stderr output: minimal_cmake_caller
```

I don't know if it's a CMake issue, or my project that is not configured correctly but I'm reporting it to you nonetheless.

---

System informations:
- OS: Kubuntu 22.04, x86_64 architecture
- ROS version: ROS2 Humble
- CMake version: 3.25.1
- Generator used: Unix Makefiles