### PR TITLE
Fix headers destination installed by ament_auto_package

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -62,7 +62,7 @@ macro(ament_auto_package)
   # export and install include directory of this package if it has one
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
     ament_export_include_directories("include")
-    install(DIRECTORY include/ DESTINATION include)
+    install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
   endif()
 
   # export and install all libraries

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -61,7 +61,7 @@ macro(ament_auto_package)
 
   # export and install include directory of this package if it has one
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    ament_export_include_directories("include")
+    ament_export_include_directories("include/${PROJECT_NAME}")
     install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
   endif()
 


### PR DESCRIPTION
To fix https://github.com/ros2/ros2/issues/1150, many packages that are resigtered in rosdistro, are fixed like https://github.com/ament/ament_index/pull/83.

This repository was not fixed at the time because it was not directly involved in installing header files.
However, all packages provided by this repository that use ament_auto_package to install header files have the issue reported in https://github.com/ros2/ros2/issues/1150, which this PR will fix.