### PR TITLE
Fix finding gtest using GTEST_DIR env variable

### DIFF
--- a/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
+++ b/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
@@ -24,18 +24,15 @@ macro(_ament_cmake_gtest_find_gtest)
     # if gtest sources were not found in a previous run
     if(NOT GTEST_FROM_SOURCE_FOUND)
       # search path for gtest includes and sources
-      set(_search_path_include "")
-      set(_search_path_src "")
+      # check the system installed path (i.e. on Ubuntu)
+      set(_search_path_include "/usr/include/gtest")
+      set(_search_path_src "/usr/src/gtest/src")
 
       # option() consider environment variable to find gtest
       if(NOT $ENV{GTEST_DIR} STREQUAL "")
         list(APPEND _search_path_include "$ENV{GTEST_DIR}/include/gtest")
         list(APPEND _search_path_src "$ENV{GTEST_DIR}/src")
       endif()
-
-      # check to system installed path (i.e. on Ubuntu)
-      set(_search_path_include "/usr/include/gtest")
-      set(_search_path_src "/usr/src/gtest/src")
 
       # check gtest_vendor path, prefer this version over a system installed
       find_package(gtest_vendor QUIET)


### PR DESCRIPTION
Fix appending search paths specified by `GTEST_DIR`. The search path variables were being overridden by the `set` command for system paths after the `GTEST_DIR` paths were appended to the variable.