### PR TITLE
[Backport]When finding Python3, use python3 executable as a hint (#507)

### DIFF
--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -22,5 +22,17 @@
 # so we need at least that version.
 cmake_minimum_required(VERSION 3.12)
 if(NOT TARGET Python3::Interpreter)
+  # We expect that Python dependencies are met for whatever Python interpreter
+  # is invoked by the "python3" executable, however this may not be the latest
+  # Python version installed on the system. The default behavior of
+  # find_package(Python3) is to use the latest version (e.x. python3.12), so we
+  # specifically look for a "python3" executable and if found, instruct
+  # find_package(Python3) to use that.
+  # On Windows, the find_package(Python3) logic is different and doesn't
+  # appear to prefer specific versions (e.x. python3.12) over plain
+  # "python.exe" so this extra logic is unnecessary there.
+  if(NOT WIN32 AND NOT Python3_EXECUTABLE)
+    find_program(Python3_EXECUTABLE python3)
+  endif()
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 endif()


### PR DESCRIPTION
The existing find_package(Python3) call will locate the Python interpreter with the latest version number. However, this may not be the system's default Python interpreter for which our dependencies have been installed.

If Python3_EXECUTABLE is not explicitly specified, use find_program to locate the Python interpreter behind the "python3" command, which is likely the system's default and the one that we want.

If no executable can be found by the name "python3", the find_program call will silently fail and the existing behavior will manifest.