### PR TITLE
Add explicit git dependency from ament_cmake_vendor_package

### DIFF
--- a/ament_cmake_vendor_package/package.xml
+++ b/ament_cmake_vendor_package/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_export_depend>ament_cmake_export_dependencies</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>git</buildtool_export_depend>
   <buildtool_export_depend>python3-vcstool</buildtool_export_depend>
 
   <test_depend>ament_cmake_test</test_depend>


### PR DESCRIPTION
The vcstool package can be used with multiple package managers, not just git. Best to be explicit about which of those package managers we want to use.

This change is motivated by the `python3-vcstool` package in Fedora/RHEL which has a soft dependency on the package managers, and therefore may not install all of them in all contexts. In particular, we currently install soft dependencies on the ROS buildfarm, but that may change in the future and we shouldn't rely on that configuration to make this package work as expected.

https://github.com/ros/rosdistro/blob/d7c80640808f5b4ddaa80f7424c69239c84d747f/rosdep/base.yaml#L1433-L1445

@azeey FYI