### PR TITLE
Support generator expressions when symlinking install(FILES)

### DIFF
--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_files.cmake
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_files.cmake
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set(__AMENT_CMAKE_SYMLINK_INSTALL_FILES_INDEX "0"
+  CACHE INTERNAL "Index for unique symlink install files")
+
 #
 # Reimplement CMake install(FILES) command to use symlinks instead of copying
 # resources.
@@ -42,8 +45,22 @@ function(ament_cmake_symlink_install_files files_keyword)
 
   if(index EQUAL -1)
     string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
+
+    # generate unique files
+    set(generated_file_base
+      "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_symlink_install_files_${__AMENT_CMAKE_SYMLINK_INSTALL_FILES_INDEX}")
+    set(generated_file_generator_suffix "${generated_file_base}_$<CONFIG>.cmake")
+    set(generated_file_variable_suffix "${generated_file_base}_\${CMAKE_INSTALL_CONFIG_NAME}.cmake")
+    math(EXPR __AMENT_CMAKE_SYMLINK_INSTALL_FILES_INDEX
+      "${__AMENT_CMAKE_SYMLINK_INSTALL_FILES_INDEX} + 1")
+    set(__AMENT_CMAKE_SYMLINK_INSTALL_FILES_INDEX "${__AMENT_CMAKE_SYMLINK_INSTALL_FILES_INDEX}"
+      CACHE INTERNAL "Index for unique symlink install files")
+
+    file(GENERATE OUTPUT "${generated_file_generator_suffix}"
+      CONTENT
+      "ament_cmake_symlink_install_files(\"${CMAKE_CURRENT_SOURCE_DIR}\" FILES ${argn_quoted})\n")
     ament_cmake_symlink_install_append_install_code(
-      "ament_cmake_symlink_install_files(\"${CMAKE_CURRENT_SOURCE_DIR}\" FILES ${argn_quoted})"
+      "include(\"${generated_file_variable_suffix}\")"
       COMMENTS "install(FILES ${argn_quoted})"
     )
   endif()


### PR DESCRIPTION
Generator expressions are supported when invoking install(FILES) normally, and this change adds support for such invocations when symlinking as well.

The change is copied from ament_cmake_symlink_install_targets, which already performs this resolution successfully: https://github.com/ament/ament_cmake/blob/fb1eda91c16a9423a8a96541e878358289e1b2b2/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_targets.cmake#L101-L117

This should add support for install commands like this one: https://github.com/ros/geometry2/blob/6df9e94363061a24ba890a6ff29771a96b0d756b/tf2_py/CMakeLists.txt#L147-L149