### PR TITLE
GTest improvements

### DIFF
--- a/ament_cmake_gmock/ament_cmake_gmock-extras.cmake
+++ b/ament_cmake_gmock/ament_cmake_gmock-extras.cmake
@@ -25,18 +25,15 @@ macro(_ament_cmake_gmock_find_gmock)
     # if gmock sources were not found in a previous run
     if(NOT GMOCK_FROM_SOURCE_FOUND)
       # search path for gmock includes and sources
-      set(_search_path_include "")
-      set(_search_path_src "")
+      # check the system installed path (i.e. on Ubuntu)
+      set(_search_path_include "/usr/include/gmock")
+      set(_search_path_src "/usr/src/gmock/src")
 
       # option() consider environment variable to find gmock
       if(NOT $ENV{GMOCK_DIR} STREQUAL "")
         list(APPEND _search_path_include "$ENV{GMOCK_DIR}/include/gmock")
         list(APPEND _search_path_src "$ENV{GMOCK_DIR}/src")
       endif()
-
-      # check to system installed path (i.e. on Ubuntu)
-      set(_search_path_include "/usr/include/gmock")
-      set(_search_path_src "/usr/src/gmock/src")
 
       # check gmock_vendor path, prefer this version over a system installed
       if(gmock_vendor_FOUND AND gmock_vendor_BASE_DIR)

--- a/ament_cmake_gmock/ament_cmake_gmock-extras.cmake
+++ b/ament_cmake_gmock/ament_cmake_gmock-extras.cmake
@@ -20,7 +20,6 @@ macro(_ament_cmake_gmock_find_gmock)
     set(_AMENT_CMAKE_GMOCK_FIND_GMOCK TRUE)
 
     find_package(ament_cmake_test QUIET REQUIRED)
-    find_package(gmock_vendor QUIET)
 
     # if gmock sources were not found in a previous run
     if(NOT GMOCK_FROM_SOURCE_FOUND)
@@ -36,6 +35,7 @@ macro(_ament_cmake_gmock_find_gmock)
       endif()
 
       # check gmock_vendor path, prefer this version over a system installed
+      find_package(gmock_vendor QUIET)
       if(gmock_vendor_FOUND AND gmock_vendor_BASE_DIR)
         list(INSERT _search_path_include 0 "${gmock_vendor_BASE_DIR}/include/gmock")
         list(INSERT _search_path_src 0 "${gmock_vendor_BASE_DIR}/src")
@@ -68,6 +68,14 @@ macro(_ament_cmake_gmock_find_gmock)
 
         set(GMOCK_FROM_SOURCE_LIBRARIES "gmock" CACHE INTERNAL "")
         set(GMOCK_FROM_SOURCE_MAIN_LIBRARIES "gmock_main" CACHE INTERNAL "")
+      else()
+        # try to find and use gmock from GTest
+        find_package(GTest QUIET)
+        if(GTest_FOUND)
+          set(GMOCK_FOUND TRUE)
+          set(GMOCK_LIBRARIES GTest::gmock)
+          set(GMOCK_MAIN_LIBRARIES GTest::gmock_main)
+        endif()
       endif()
     endif()
 

--- a/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
+++ b/ament_cmake_gtest/ament_cmake_gtest-extras.cmake
@@ -68,6 +68,15 @@ macro(_ament_cmake_gtest_find_gtest)
 
         set(GTEST_FROM_SOURCE_LIBRARIES "gtest" CACHE INTERNAL "")
         set(GTEST_FROM_SOURCE_MAIN_LIBRARIES "gtest_main" CACHE INTERNAL "")
+      else()
+        # try to find and use gtest from GTest
+        find_package(GTest QUIET)
+        if(GTest_FOUND)
+          set(GTEST_FOUND TRUE)
+          set(GTEST_LIBRARIES GTest::gtest)
+          set(GTEST_MAIN_LIBRARIES GTest::gtest_main)
+          set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
+        endif()
       endif()
     endif()
 


### PR DESCRIPTION
- make some gmock/gtest improvements
  - port https://github.com/ament/ament_cmake/pull/543/commits/8915ab8e43206467d11df14f16e2a2681e11b458 to `ament_cmake_gmock-extras`
  - add option to use system' `gtest` or `gmock` targets from `GTest`
    - don't change the old building behavior