### PR TITLE
Create destination directory during symlink install

### DIFF
--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
@@ -55,6 +55,11 @@ function(ament_cmake_symlink_install_directory cmake_current_source_dir)
         # remove trailing slash
         string(SUBSTRING "${dir}" 0 ${offset} dir)
       endif()
+      
+      # Create destination directory.
+      # This does *not* solve the problem of empty directories WITHIN the install tree,
+      # but does make sure that the top-level directory specified by the caller gets created.
+      file(MAKE_DIRECTORY "${destination}")
 
       # glob recursive files
       set(relative_files "")


### PR DESCRIPTION
Minimal fix for #568.

As I wrote in the comment, this doesn't fix the issue of recursive directory trees that might contain empty folders, but it does at least create the directory that the user specified in their invocation of `install()`, which is what my specific issue was.