### PR TITLE
[backport] Fix headers destination installed by ament_auto_package (#540)

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -61,8 +61,8 @@ macro(ament_auto_package)
 
   # export and install include directory of this package if it has one
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    ament_export_include_directories("include")
-    install(DIRECTORY include/ DESTINATION include)
+    ament_export_include_directories("include/${PROJECT_NAME}")
+    install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
   endif()
 
   # export and install all libraries


### PR DESCRIPTION
This pull-request backports a bug fix for `ament_auto_package` to jazzy branch.
#540 changes the header install target, but it shouldn't be destructive since it updating dependencies properly.