### PR TITLE
Add `USE_SCOPED_HEADER_INSTALL_DIR` option to ament_auto_package

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -77,7 +77,7 @@ macro(ament_auto_package)
     else()
       ament_export_include_directories("include")
       install(DIRECTORY include/ DESTINATION include)
-      message(WARNING
+      message(
         "In this package, headers install destination is set to `include` "
         "by ament_auto_package. It is recommended to install "
         "`include/${PROJECT_NAME}` instead and will be the default behavior "

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -84,6 +84,7 @@ macro(ament_auto_package)
         "of ament_auto_package from ROS 2 Kilted Kaiju. On distributions before "
         "Kilted, ament_auto_package behaves the same way when you use "
         "USE_SCOPED_HEADER_INSTALL_DIR option.")
+    endif()
   endif()
 
   # export and install all libraries

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -77,6 +77,13 @@ macro(ament_auto_package)
     else()
       ament_export_include_directories("include")
       install(DIRECTORY include/ DESTINATION include)
+      message(WARNING
+        "In this package, headers install destination is set to `include` "
+        "by ament_auto_package. It is recommended to install "
+        "`include/${PROJECT_NAME}` instead and will be the default behavior "
+        "of ament_auto_package from ROS 2 Kilted Kaiju. On distributions before "
+        "Kilted, ament_auto_package behaves the same way when you use "
+        "USE_SCOPED_HEADER_INSTALL_DIR option.")
   endif()
 
   # export and install all libraries

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -28,6 +28,12 @@
 # :param INSTALL_TO_SHARE: a list of directories to be installed to the
 #   package's share directory
 # :type INSTALL_TO_SHARE: list of strings
+# :param USE_SCOPED_HEADER_INSTALL_DIR: if set, install headers to
+#   `include/${PROJECT_NAME}` instead of `include` directory.
+#   This helps prevent include path pollution when user package is
+#   merge-installed underlay package.
+#   For detail, see https://github.com/ros2/ros2/issues/1150.
+# :type USE_SCOPED_HEADER_INSTALL_DIR: option
 # :param ARGN: any other arguments are passed through to ament_package()
 # :type ARGN: list of strings
 #
@@ -43,7 +49,11 @@
 #
 
 macro(ament_auto_package)
-  cmake_parse_arguments(_ARG_AMENT_AUTO_PACKAGE "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
+  cmake_parse_arguments(_ARG_AMENT_AUTO_PACKAGE
+    "INSTALL_TO_PATH;USE_SCOPED_HEADER_INSTALL_DIR"
+    ""
+    "INSTALL_TO_SHARE"
+    ${ARGN})
   # passing all unparsed arguments to ament_package()
 
   # export all found build dependencies which are also run dependencies
@@ -61,8 +71,12 @@ macro(ament_auto_package)
 
   # export and install include directory of this package if it has one
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    ament_export_include_directories("include")
-    install(DIRECTORY include/ DESTINATION include)
+    if(_ARG_AMENT_AUTO_PACKAGE_USE_SCOPED_HEADER_INSTALL_DIR)
+      ament_export_include_directories("include/${PROJECT_NAME}")
+      install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+    else()
+      ament_export_include_directories("include")
+      install(DIRECTORY include/ DESTINATION include)
   endif()
 
   # export and install all libraries


### PR DESCRIPTION
This is a backport of #540 with backward-compatible workaround discussed with @sloretz in #574.
  
This pull-request adds `USE_SCOPED_HEADER_INSTALL_DIR` option to `ament_auto_package` function.
If you set the option, header install destination will switch to `include/${PROJECT_NAME}` from `include`.
If you do not set the option and your package has include directory, `ament_auto_package` will install headers to lagacy destination, `include` directory and show warning message like below.

```
Starting >>> timer_experiments
--- stderr: timer_experiments
CMake Warning at /__w/ros2_sandbox/ros2_sandbox/install/share/ament_cmake_auto/cmake/ament_auto_package.cmake:80 (message):
  In this package, headers install destination is set to `include` by
  ament_auto_package.  It is recommended to install
  `include/timer_experiments` instead and will be the default behavior of
  ament_auto_package from ROS 2 Kilted Kaiju.  On distributions before
  Kilted, ament_auto_package behaves the same way when you use
  USE_SCOPED_HEADER_INSTALL_DIR option.
Call Stack (most recent call first):
  CMakeLists.txt:33 (ament_auto_package)
```

With this option, users can switch the behavior of `ament_auto_package` and transition to the new behavior smoothly.

If this pull-request is merged, I'll submit the PRs with same content to `iron` and `jazzy` branch.

## Tests

build testing and install directory checking are performed on GitHub Actions in my repository.
https://github.com/HansRobo/ros2_sandbox/pull/2

There are 2 packages that have include directory.

- `parent_package` : use `ament_auto_package` with `USE_SCOPED_HEADER_INSTALL_DIR` option
- `timer_experiments` : use `ament_auto_package` without `USE_SCOPED_HEADER_INSTALL_DIR` option

### build log 

**expected  behavior**

- `parent_package`: no warning
- `timer_experiments`: shows implemented warning  

**actual behavior**

The build logs have expected behavior.

https://github.com/HansRobo/ros2_sandbox/actions/runs/14345897198/job/40215478181?pr=2#step:8:53

```
Starting >>> parent_package
Starting >>> clock_publisher
Starting >>> timer_experiments
--- stderr: timer_experiments
CMake Warning at /__w/ros2_sandbox/ros2_sandbox/install/share/ament_cmake_auto/cmake/ament_auto_package.cmake:80 (message):
  In this package, headers install destination is set to `include` by
  ament_auto_package.  It is recommended to install
  `include/timer_experiments` instead and will be the default behavior of
  ament_auto_package from ROS 2 Kilted Kaiju.  On distributions before
  Kilted, ament_auto_package behaves the same way when you use
  USE_SCOPED_HEADER_INSTALL_DIR option.
Call Stack (most recent call first):
  CMakeLists.txt:33 (ament_auto_package)


---
Finished <<< timer_experiments [5.47s]
Finished <<< parent_package [6.04s]
```


### install directory

**expected  behavior**

- `parent_package`: headers are installed to `include/parent_package/parent_package`
- `timer_experiments`: headers are installed to `include/timer_experiments`

**actual behavior**

The installed location is as expected.

https://github.com/HansRobo/ros2_sandbox/actions/runs/14345897198/job/40215478181?pr=2#step:9:7

```
tree ./install/include
./install/include
├── parent_package
│   └── parent_package
│       └── test_node.hpp
└── timer_experiments
    └── timer_statistics.hpp
```