### PR TITLE
Revert "Removed deprecated ament_cmake_target_dependencies"

### DIFF
--- a/ament_cmake_target_dependencies/ament_cmake_target_dependencies-extras.cmake
+++ b/ament_cmake_target_dependencies/ament_cmake_target_dependencies-extras.cmake
@@ -21,3 +21,5 @@ find_package(ament_cmake_libraries QUIET REQUIRED)
 
 include(
   "${ament_cmake_target_dependencies_DIR}/ament_get_recursive_properties.cmake")
+include(
+  "${ament_cmake_target_dependencies_DIR}/ament_target_dependencies.cmake")

--- a/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
+++ b/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake
@@ -1,0 +1,183 @@
+# Copyright 2014-2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add the interface targets or definitions, include directories and libraries
+# of packages to a target.
+#
+# Each package name must have been find_package()-ed before.
+# Additionally the exported variables must have a prefix with the same case
+# and the suffixes must be either _INTERFACES or _DEFINITIONS, _INCLUDE_DIRS,
+# _LIBRARIES, _LIBRARY_DIRS, and _LINK_FLAGS.
+# If _INTERFACES is not empty it will be used exclusively, otherwise the other
+# variables are being used.
+# If _LIBRARY_DIRS is not empty, _LIBRARIES which are not absolute paths already
+# will be searched in those directories and their absolute paths will be used instead.
+#
+# :param target: the target name
+# :type target: string
+# :param ARGN: a list of package names, which can optionally start
+#   with a SYSTEM keyword, followed by an INTERFACE or PUBLIC keyword.
+#   If it starts with a SYSTEM keyword, it will be used in
+#   target_include_directories() calls.
+#   If it starts (or follows) with an INTERFACE or PUBLIC keyword,
+#   this keyword will be used in the target_*() calls.
+# :type ARGN: list of strings
+#
+# @public
+#
+function(ament_target_dependencies target)
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR "ament_target_dependencies() the first argument must be a valid target name")
+  endif()
+  if(${ARGC} GREATER 0)
+    cmake_parse_arguments(ARG "INTERFACE;PUBLIC;SYSTEM" "" "" ${ARGN})
+    set(ARGVIND 1)
+    set(system_keyword "")
+    set(optional_keyword "")
+    set(required_keyword "PUBLIC")
+    if(ARG_SYSTEM)
+      if(NOT "${ARGV${ARGVIND}}" STREQUAL "SYSTEM")
+        message(FATAL_ERROR "ament_target_dependencies() SYSTEM keyword is only allowed before the package names and other keywords")
+      endif()
+      set(system_keyword SYSTEM)
+      math(EXPR ARGVIND "${ARGVIND} + 1")
+    endif()
+    if(ARG_INTERFACE)
+      if(NOT "${ARGV${ARGVIND}}" STREQUAL "INTERFACE")
+        message(FATAL_ERROR "ament_target_dependencies() INTERFACE keyword is only allowed before the package names")
+      endif()
+      set(optional_keyword INTERFACE)
+      set(required_keyword INTERFACE)
+    endif()
+    if(ARG_PUBLIC)
+      if(NOT "${ARGV${ARGVIND}}" STREQUAL "PUBLIC")
+        message(FATAL_ERROR "ament_target_dependencies() PUBLIC keyword is only allowed before the package names")
+      endif()
+      set(optional_keyword PUBLIC)
+    endif()
+
+    # Collect targets to use in deprecation warning
+    set(upstream_targets_for_deprecation_warning "")
+    foreach(package_name ${ARG_UNPARSED_ARGUMENTS})
+      foreach(_target IN LISTS ${package_name}_TARGETS)
+        if(TARGET ${_target})
+          if(_target MATCHES "(.+)::.+__rosidl_.+")
+            # suggest ${package_name_TARGETS} for message packages
+            list_append_unique(upstream_targets_for_deprecation_warning "\${${CMAKE_MATCH_1}_TARGETS}")
+          else()
+            list_append_unique(upstream_targets_for_deprecation_warning ${_target})
+          endif()
+        endif()
+      endforeach()
+    endforeach()
+    list(SORT upstream_targets_for_deprecation_warning)
+    list(JOIN upstream_targets_for_deprecation_warning "\n    " upstream_targets_for_deprecation_warning)
+    message(DEPRECATION "ament_target_dependencies() is deprecated. "
+    "Use target_link_libraries() with modern CMake targets instead. "
+    "Try replacing this call with:\n"
+    "  target_link_libraries(${target} ${required_keyword}\n"
+    "    ${upstream_targets_for_deprecation_warning}\n"
+    "  )\n")
+
+    set(definitions "")
+    set(include_dirs "")
+    set(interfaces "")
+    set(libraries "")
+    set(link_flags "")
+    foreach(package_name ${ARG_UNPARSED_ARGUMENTS})
+      if(NOT "${${package_name}_FOUND}")
+        message(FATAL_ERROR "ament_target_dependencies() the passed package name '${package_name}' was not found before")
+      endif()
+      # if a package provides modern CMake interface targets use them
+      # exclusively assuming the classic CMake variables only exist for
+      # backward compatibility
+      set(use_modern_cmake FALSE)
+      if(NOT "${${package_name}_TARGETS}" STREQUAL "")
+        foreach(_target ${${package_name}_TARGETS})
+          # only use actual targets
+          # in case a package uses this variable for other content
+          if(TARGET "${_target}")
+            list_append_unique(interfaces ${_target})
+            set(use_modern_cmake TRUE)
+          endif()
+        endforeach()
+      endif()
+      if(NOT use_modern_cmake AND NOT "${${package_name}_INTERFACES}" STREQUAL "")
+        foreach(_interface ${${package_name}_INTERFACES})
+          # only use actual targets
+          # in case a package uses this variable for other content
+          if(TARGET "${_interface}")
+            list_append_unique(interfaces ${_interface})
+            set(use_modern_cmake TRUE)
+          endif()
+        endforeach()
+        if(use_modern_cmake)
+          message(DEPRECATION
+            "Package ${package_name} is exporting the variable "
+            "${package_name}_INTERFACES which is deprecated, it should export
+            ${package_name}_TARGETS instead")
+        endif()
+      endif()
+      if(NOT use_modern_cmake)
+        # otherwise use the classic CMake variables
+        list_append_unique(definitions ${${package_name}_DEFINITIONS})
+        list_append_unique(include_dirs ${${package_name}_INCLUDE_DIRS})
+        foreach(library ${${package_name}_LIBRARIES})
+          if(NOT "${${package_name}_LIBRARY_DIRS}" STREQUAL "")
+            if(NOT IS_ABSOLUTE ${library} OR NOT EXISTS ${library})
+              unset(lib CACHE)
+              find_library(lib NAMES ${library} PATHS ${${package_name}_LIBRARY_DIRS} NO_DEFAULT_PATH)
+              if(lib)
+                set(library ${lib})
+              endif()
+            endif()
+          endif()
+          list(APPEND libraries ${library})
+        endforeach()
+        list_append_unique(link_flags ${${package_name}_LINK_FLAGS})
+      endif()
+    endforeach()
+    if(NOT ARG_INTERFACE)
+      target_compile_definitions(${target}
+        ${required_keyword} ${definitions})
+      # the interface include dirs must be ordered
+      set(interface_include_dirs)
+      foreach(interface ${interfaces})
+        get_target_property(_include_dirs ${interface} INTERFACE_INCLUDE_DIRECTORIES)
+        if(_include_dirs)
+          list_append_unique(interface_include_dirs ${_include_dirs})
+        endif()
+      endforeach()
+      ament_include_directories_order(ordered_interface_include_dirs ${interface_include_dirs})
+      # the interface include dirs are used privately to ensure proper order
+      # and the interfaces cover the public case
+      target_include_directories(${target} ${system_keyword}
+        PRIVATE ${ordered_interface_include_dirs})
+    endif()
+    ament_include_directories_order(ordered_include_dirs ${include_dirs})
+    target_link_libraries(${target}
+      ${optional_keyword} ${interfaces})
+    target_include_directories(${target} ${system_keyword}
+      ${required_keyword} ${ordered_include_dirs})
+    if(NOT ARG_INTERFACE)
+      ament_libraries_deduplicate(unique_libraries ${libraries})
+      target_link_libraries(${target}
+        ${optional_keyword} ${unique_libraries})
+      foreach(link_flag IN LISTS link_flags)
+        set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS " ${link_flag} ")
+      endforeach()
+    endif()
+  endif()
+endfunction()


### PR DESCRIPTION
Reverts ament/ament_cmake#583

This temporarily restores ament_target_dependencies to give ROS Rolling package maintainers more time with the deprecation warning. My intent is to revert this for a fixed period of time, maybe 6 months?