### PR TITLE
Do not error on USE_SCOPED_HEADER_INSTALL_DIR

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -28,6 +28,8 @@
 # :param INSTALL_TO_SHARE: a list of directories to be installed to the
 #   package's share directory
 # :type INSTALL_TO_SHARE: list of strings
+# :param USE_SCOPED_HEADER_INSTALL_DIR: deprecated after Jazzy
+# :type USE_SCOPED_HEADER_INSTALL_DIR: option
 # :param ARGN: any other arguments are passed through to ament_package()
 # :type ARGN: list of strings
 #
@@ -43,7 +45,11 @@
 #
 
 macro(ament_auto_package)
-  cmake_parse_arguments(_ARG_AMENT_AUTO_PACKAGE "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
+  cmake_parse_arguments(_ARG_AMENT_AUTO_PACKAGE
+    "INSTALL_TO_PATH;USE_SCOPED_HEADER_INSTALL_DIR"
+    ""
+    "INSTALL_TO_SHARE"
+    ${ARGN})
   # passing all unparsed arguments to ament_package()
 
   # export all found build dependencies which are also run dependencies


### PR DESCRIPTION
Prevents:

```                                          
CMake Error at /opt/ros/kilted/share/ament_cmake_core/cmake/core/ament_package.cmake:74 (message):
  ament_package() called with unused arguments: USE_SCOPED_HEADER_INSTALL_DIR
Call Stack (most recent call first):
  /opt/ros/kilted/share/ament_cmake_core/cmake/core/ament_package.cmake:68 (_ament_package)
  /opt/ros/kilted/share/ament_cmake_auto/cmake/ament_auto_package.cmake:110 (ament_package)
  CMakeLists.txt:70 (ament_auto_package)
```

In cases where a package is maintained for kilted, rolling & jazzy on the same branch.

This can be reverted after Jazzy is EOL.

Relates to: https://github.com/ament/ament_cmake/pull/577