### PR TITLE
Migrate package dependency from vcstool to vcs2l.

### DIFF
--- a/ament_cmake_vendor_package/package.xml
+++ b/ament_cmake_vendor_package/package.xml
@@ -17,7 +17,7 @@
   <buildtool_export_depend>ament_cmake_export_dependencies</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>git</buildtool_export_depend>
-  <buildtool_export_depend>python3-vcstool</buildtool_export_depend>
+  <buildtool_export_depend>python3-vcs2l</buildtool_export_depend>
 
   <test_depend>ament_cmake_test</test_depend>
 


### PR DESCRIPTION
> [!NOTE]  
> `python3-vcs2l` needs to be integrated with [rosdep](https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml) prior to the review of this PR.

## Pull Request Description

Migrated `ament_cmake_vendor_package` dependency to use the maintained [vcs2l](https://github.com/ros-infrastructure/vcs2l) package.

## Future Work

This PR needs to be backported to the `kilted` and `jazzy` branches for consistency.