### PR TITLE
Respect find_package(QUIET) in chains from ament_cmake_core

### DIFF
--- a/ament_cmake_core/cmake/core/python.cmake
+++ b/ament_cmake_core/cmake/core/python.cmake
@@ -34,5 +34,10 @@ if(NOT TARGET Python3::Interpreter)
   cmake_policy(SET CMP0094 NEW)
   set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  set(_ARG_QUIET)
+  if(ament_cmake_core_FIND_QUIETLY)
+    set(_ARG_QUIET QUIET)
+  endif()
+
+  find_package(Python3 REQUIRED COMPONENTS Interpreter ${_ARG_QUIET})
 endif()


### PR DESCRIPTION
When `find_package(ament_cmake_core QUIET)` is called, any chained calls to `find_package()` should use `ament_cmake_core_FIND_QUIETLY` to inherit the same behavior.

Docs: https://cmake.org/cmake/help/latest/command/find_package.html#package-file-interface-variables

Under the existing behavior, the following console output appears even if `find_package(ament_cmake_core QUIET)` is used:
```console
-- Found Python3: /usr/bin/python3 (found version "3.13.7") found components: Interpreter
```