### PR TITLE
Address ament_lint_cmake regressions

### DIFF
--- a/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
+++ b/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in
@@ -55,7 +55,7 @@ function(ament_cmake_symlink_install_directory cmake_current_source_dir)
         # remove trailing slash
         string(SUBSTRING "${dir}" 0 ${offset} dir)
       endif()
-      
+
       # Create destination directory.
       # This does *not* solve the problem of empty directories WITHIN the install tree,
       # but does make sure that the top-level directory specified by the caller gets created.

--- a/ament_cmake_export_targets/cmake/ament_export_targets.cmake
+++ b/ament_cmake_export_targets/cmake/ament_export_targets.cmake
@@ -22,7 +22,7 @@
 # :param HAS_LIBRARY_TARGET: if set, an environment variable will be defined
 #   so that the library can be found at runtime
 # :type HAS_LIBRARY_TARGET: option
-# :keyword NAMESPACE: the exported namespace for the target if set. 
+# :keyword NAMESPACE: the exported namespace for the target if set.
 #    The default is the value of ``${PROJECT_NAME}::``.
 #    This is an advanced option. It should be used carefully and clearly documented
 #    in a usage guide for any package that makes use of this option.

--- a/ament_cmake_gen_version_h/cmake/ament_generate_version_header.cmake
+++ b/ament_cmake_gen_version_h/cmake/ament_generate_version_header.cmake
@@ -73,7 +73,7 @@
 # :type target: string
 # :param HEADER_PATH: Path of the generated header including the file name
 #   that describes how it should be included by downstream targets.
-#   The default is `${PROJECT_NAME}/version.h` 
+#   The default is `${PROJECT_NAME}/version.h`
 # :type HEADER_PATH: string
 # :param INSTALL_PATH: Path that the header should be installed at.
 #   The default value is "include/${PROJECT_NAME}" to avoid include directory
@@ -153,7 +153,7 @@ function(ament_generate_version_header target)
 
   # Make generated header includable to this and downstream targets
   get_target_property(type "${target}" TYPE)
-  if (${type} STREQUAL "INTERFACE_LIBRARY")
+  if(${type} STREQUAL "INTERFACE_LIBRARY")
     set(keyword "INTERFACE")
   else()
     set(keyword "PUBLIC")

--- a/ament_cmake_gen_version_h/cmake/generate_version_header.cmake.in
+++ b/ament_cmake_gen_version_h/cmake/generate_version_header.cmake.in
@@ -8,7 +8,8 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 # Generated from generate_version_header.cmake.in

--- a/ament_cmake_libraries/cmake/ament_libraries_deduplicate.cmake
+++ b/ament_cmake_libraries/cmake/ament_libraries_deduplicate.cmake
@@ -26,9 +26,17 @@
 # @public
 #
 macro(ament_libraries_deduplicate VAR)
-  string(REGEX REPLACE "(^|;)(debug|optimized|general);([^;]+)" "\\1\\2${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}\\3" _packed "${ARGN}")
+  string(REGEX REPLACE
+    "(^|;)(debug|optimized|general);([^;]+)"
+    "\\1\\2${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}\\3"
+    _packed
+    "${ARGN}")
   list(REVERSE _packed)
   list(REMOVE_DUPLICATES _packed)
   list(REVERSE _packed)
-  string(REGEX REPLACE "(^|;)(debug|optimized|general)${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}([^;]+)" "\\1\\2;\\3" ${VAR} "${_packed}")
+  string(REGEX REPLACE
+    "(^|;)(debug|optimized|general)${AMENT_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}([^;]+)"
+    "\\1\\2;\\3"
+    ${VAR}
+    "${_packed}")
 endmacro()


### PR DESCRIPTION
We don't actively enforce linters in `ament_cmake`, but it's still nice to be consistent.

Addresses:
```console
$ ament_lint_cmake
ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install.cmake.in:58: Line ends in whitespace [whitespace/eol]

ament_cmake_export_targets/cmake/ament_export_targets.cmake:25: Line ends in whitespace [whitespace/eol]

ament_cmake_gen_version_h/cmake/ament_generate_version_header.cmake:76: Line ends in whitespace [whitespace/eol]
ament_cmake_gen_version_h/cmake/ament_generate_version_header.cmake:156: Extra spaces between 'if' and its () [whitespace/extra]

ament_cmake_gen_version_h/cmake/generate_version_header.cmake.in:11: Lines should be <= 140 characters long [linelength]

ament_cmake_libraries/cmake/ament_libraries_deduplicate.cmake:33: Lines should be <= 140 characters long [linelength]

ament_cmake_python/test/test_package/CMakeLists.txt:17: Mismatching spaces inside () after command [whitespace/mismatch]


7 errors
```