### PR TITLE
Improve byte-compile in ament_cmake_python

### DIFF
--- a/ament_cmake_python/cmake/ament_python_install_module.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_module.cmake
@@ -20,7 +20,7 @@
 # :param DESTINATION_SUFFIX: the base package to install the module to
 #   (default: empty, install as a top level module)
 # :type DESTINATION_SUFFIX: string
-# :param SKIP_COMPILE: if set do not compile the installed module
+# :param SKIP_COMPILE: if set do not byte-compile the installed module
 # :type SKIP_COMPILE: option
 #
 macro(ament_python_install_module)
@@ -60,12 +60,14 @@ function(_ament_cmake_python_install_module module_file)
   get_filename_component(module_file "${module_file}" NAME)
   if(NOT ARG_SKIP_COMPILE)
     get_executable_path(python_interpreter Python3::Interpreter CONFIGURE)
+    set(_bytecompile_target "\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${module_file}")
     # compile Python files
     install(CODE
-      "execute_process(
+      "message(STATUS \"Byte-compiling: ${_bytecompile_target}\")
+      execute_process(
         COMMAND
-        \"${python_interpreter}\" \"-m\" \"compileall\"
-        \"${CMAKE_INSTALL_PREFIX}/${destination}/${module_file}\"
+        \"${python_interpreter}\" \"-m\" \"compileall\" \"-q\"
+        \"${_bytecompile_target}\"
       )"
     )
   endif()

--- a/ament_cmake_python/cmake/ament_python_install_module.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_module.cmake
@@ -60,7 +60,7 @@ function(_ament_cmake_python_install_module module_file)
   get_filename_component(module_file "${module_file}" NAME)
   if(NOT ARG_SKIP_COMPILE)
     get_executable_path(python_interpreter Python3::Interpreter CONFIGURE)
-    set(_bytecompile_target "\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${module_file}")
+    set(_bytecompile_target "\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${destination}/${module_file}")
     # compile Python files
     install(CODE
       "message(STATUS \"Byte-compiling: ${_bytecompile_target}\")

--- a/ament_cmake_python/cmake/ament_python_install_package.cmake
+++ b/ament_cmake_python/cmake/ament_python_install_package.cmake
@@ -190,12 +190,14 @@ setup(
 
   if(NOT ARG_SKIP_COMPILE)
     get_executable_path(python_interpreter_config Python3::Interpreter CONFIGURE)
+    set(_bytecompile_target "\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${package_name}")
     # compile Python files
     install(CODE
-      "execute_process(
+      "message(STATUS \"Byte-compiling: ${_bytecompile_target}\")
+      execute_process(
         COMMAND
-        \"${python_interpreter_config}\" \"-m\" \"compileall\"
-        \"${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${package_name}\"
+        \"${python_interpreter_config}\" \"-m\" \"compileall\" \"-q\"
+        \"${_bytecompile_target}\"
       )"
     )
   endif()


### PR DESCRIPTION
- Align CMake documentation
- Suppress verbose output from compileall
- Add a CMake-like installation message
- Fix support for DESTDIR-based installations

This change should enable Python byte-compilation for RPM packages produced by the buildfarm, where the current code fails to target the correct installation directory.