### PR TITLE
Add ament_set_default_language_standards

### DIFF
--- a/ament_cmake_core/CMakeLists.txt
+++ b/ament_cmake_core/CMakeLists.txt
@@ -8,6 +8,7 @@ include("ament_cmake_core-extras.cmake" NO_POLICY_SCOPE)
 include("ament_cmake_environment-extras.cmake" NO_POLICY_SCOPE)
 include("ament_cmake_environment_hooks-extras.cmake" NO_POLICY_SCOPE)
 include("ament_cmake_index-extras.cmake" NO_POLICY_SCOPE)
+include("ament_cmake_language_standards.cmake" NO_POLICY_SCOPE)
 include("ament_cmake_uninstall_target-extras.cmake" NO_POLICY_SCOPE)
 # must be after uninstall_target
 include("ament_cmake_symlink_install-extras.cmake" NO_POLICY_SCOPE)
@@ -24,6 +25,7 @@ ament_package(
   "ament_cmake_environment-extras.cmake"
   "ament_cmake_environment_hooks-extras.cmake"
   "ament_cmake_index-extras.cmake"
+  "ament_cmake_language_standards.cmake"
   "ament_cmake_package_templates-extras.cmake"
   "ament_cmake_uninstall_target-extras.cmake"
   "ament_cmake_symlink_install-extras.cmake"  # must be after uninstall_target

--- a/ament_cmake_core/ament_cmake_language_standards.cmake
+++ b/ament_cmake_core/ament_cmake_language_standards.cmake
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-macro(ament_set_default_language_standards)
+macro(  )
   # C++
   if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
   endif()
 
   if(NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)

--- a/ament_cmake_core/ament_cmake_language_standards.cmake
+++ b/ament_cmake_core/ament_cmake_language_standards.cmake
@@ -1,0 +1,29 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+macro(ament_set_default_language_standards)
+  # C++
+  if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+  endif()
+
+  if(NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  endif()
+
+  # C
+  if(NOT DEFINED CMAKE_C_STANDARD)
+    set(CMAKE_C_STANDARD 17)
+  endif()
+endmacro()

--- a/ament_cmake_core/ament_cmake_language_standards.cmake
+++ b/ament_cmake_core/ament_cmake_language_standards.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-macro(  )
+macro(ament_set_default_language_standards)
   # C++
   if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 20)

--- a/ament_cmake_gen_version_h/CMakeLists.txt
+++ b/ament_cmake_gen_version_h/CMakeLists.txt
@@ -2,15 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 project(ament_cmake_gen_version_h)
 find_package(ament_cmake_core REQUIRED)
 
-# GTest needs it, Default to C11
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 11)
-endif()
-# GTest needs it, Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
+ament_set_default_language_standards()
 
 include(CTest)
 if(BUILD_TESTING)


### PR DESCRIPTION
Can use one point as a single source of truth for C++/C version.