### PR TITLE
Create CMake targets in ament_auto_package

### DIFF
--- a/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
@@ -68,7 +68,8 @@ macro(ament_auto_add_executable target)
   # add include directory of this package if it exists
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
     target_include_directories("${target}" PUBLIC
-      "${CMAKE_CURRENT_SOURCE_DIR}/include")
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
   endif()
   # link against other libraries of this package
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -69,10 +69,12 @@ macro(ament_auto_add_library target)
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
     if(ARG_INTERFACE)
       target_include_directories("${target}" INTERFACE
-        "${CMAKE_CURRENT_SOURCE_DIR}/include")
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
     else()
       target_include_directories("${target}" PUBLIC
-        "${CMAKE_CURRENT_SOURCE_DIR}/include")
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
     endif()
   endif()
   # link against other libraries of this package

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -71,9 +71,13 @@ macro(ament_auto_package)
     install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
   endif()
 
+  set(_has_targets FALSE)
+  set(_has_library_targets FALSE)
+
   # export and install all libraries
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
-    set(without_interfaces "")
+    set(_has_targets TRUE)
+    set(_has_library_targets TRUE)
     foreach(library_name ${${PROJECT_NAME}_LIBRARIES})
       get_target_property(library_type ${library_name} TYPE)
       if(NOT "${library_type}" STREQUAL "INTERFACE_LIBRARY")
@@ -83,7 +87,8 @@ macro(ament_auto_package)
 
     ament_export_libraries(${without_interfaces})
     install(
-      TARGETS ${without_interfaces}
+      TARGETS ${${PROJECT_NAME}_LIBRARIES}
+      EXPORT export_${PROJECT_NAME}
       ARCHIVE DESTINATION lib
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin
@@ -92,6 +97,7 @@ macro(ament_auto_package)
 
   # install all executables
   if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
+    set(_has_targets TRUE)
     if(_ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_PATH)
       set(_destination "bin")
     else()
@@ -99,8 +105,18 @@ macro(ament_auto_package)
     endif()
     install(
       TARGETS ${${PROJECT_NAME}_EXECUTABLES}
+      EXPORT export_${PROJECT_NAME}
       DESTINATION ${_destination}
     )
+  endif()
+
+  # export all targets
+  if(_has_targets)
+    if(_has_library_targets)
+      ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+    else()
+      ament_export_targets(export_${PROJECT_NAME})
+    endif()
   endif()
 
   # install directories to share

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -76,8 +76,8 @@ macro(ament_auto_package)
   
   # export and install all libraries
   if(NOT "${${PROJECT_NAME}_LIBRARIES}" STREQUAL "")
-  set(_has_targets TRUE)
-  set(_has_library_targets TRUE)
+    set(_has_targets TRUE)
+    set(_has_library_targets TRUE)
     set(without_interfaces "")
     foreach(library_name ${${PROJECT_NAME}_LIBRARIES})
       get_target_property(library_type ${library_name} TYPE)

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -73,12 +73,12 @@ macro(ament_auto_package)
 
   set(_has_targets FALSE)
   set(_has_library_targets FALSE)
-  set(without_interfaces "")
-
+  
   # export and install all libraries
   if(NOT "${${PROJECT_NAME}_LIBRARIES}" STREQUAL "")
-    set(_has_targets TRUE)
-    set(_has_library_targets TRUE)
+  set(_has_targets TRUE)
+  set(_has_library_targets TRUE)
+    set(without_interfaces "")
     foreach(library_name ${${PROJECT_NAME}_LIBRARIES})
       get_target_property(library_type ${library_name} TYPE)
       if(NOT "${library_type}" STREQUAL "INTERFACE_LIBRARY")

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -78,6 +78,8 @@ macro(ament_auto_package)
   if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
     set(_has_targets TRUE)
     set(_has_library_targets TRUE)
+    set(without_interfaces "")
+
     foreach(library_name ${${PROJECT_NAME}_LIBRARIES})
       get_target_property(library_type ${library_name} TYPE)
       if(NOT "${library_type}" STREQUAL "INTERFACE_LIBRARY")
@@ -85,7 +87,9 @@ macro(ament_auto_package)
       endif()
     endforeach()
 
-    ament_export_libraries(${without_interfaces})
+    if(NOT ${without_interfaces} STREQUAL "")
+      ament_export_libraries(${without_interfaces})
+    endif()
     install(
       TARGETS ${${PROJECT_NAME}_LIBRARIES}
       EXPORT export_${PROJECT_NAME}

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -73,23 +73,19 @@ macro(ament_auto_package)
 
   set(_has_targets FALSE)
   set(_has_library_targets FALSE)
+  set(without_interfaces "")
 
   # export and install all libraries
-  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
+  if(NOT "${${PROJECT_NAME}_LIBRARIES}" STREQUAL "")
     set(_has_targets TRUE)
     set(_has_library_targets TRUE)
-    set(without_interfaces "")
-
     foreach(library_name ${${PROJECT_NAME}_LIBRARIES})
       get_target_property(library_type ${library_name} TYPE)
       if(NOT "${library_type}" STREQUAL "INTERFACE_LIBRARY")
         list(APPEND without_interfaces ${library_name})
       endif()
     endforeach()
-
-    if(NOT ${without_interfaces} STREQUAL "")
-      ament_export_libraries(${without_interfaces})
-    endif()
+    ament_export_libraries(${without_interfaces})
     install(
       TARGETS ${${PROJECT_NAME}_LIBRARIES}
       EXPORT export_${PROJECT_NAME}
@@ -100,7 +96,7 @@ macro(ament_auto_package)
   endif()
 
   # install all executables
-  if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
+  if(NOT "${${PROJECT_NAME}_EXECUTABLES}" STREQUAL "")
     set(_has_targets TRUE)
     if(_ARG_AMENT_AUTO_PACKAGE_INSTALL_TO_PATH)
       set(_destination "bin")


### PR DESCRIPTION
Addresses #624 and updated PR of #455. As already mentioned I tested the targets against pal_statistics as well as some autoware packages. If requested I can also change the behaviour to opt-in with a flag opposed to automatically. Major changes to #455 are:
- Also export executables
- Fix detection of libraries and executables
- Also change handling of headers for executables