### PR TITLE
ament_cmake_vendor: also generate powershell hooks

### DIFF
--- a/ament_cmake_vendor_package/cmake/ament_vendor.cmake
+++ b/ament_cmake_vendor_package/cmake/ament_vendor.cmake
@@ -121,6 +121,7 @@ macro(ament_vendor TARGET_NAME)
         ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package_cmake_prefix.bat.in)
         ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package_cmake_prefix.dsv.in)
         ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package_cmake_prefix.sh.in)
+        ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package_cmake_prefix.ps1.in)
       else()
         list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS ${ament_cmake_vendor_package_DIR}/templates/vendor_package_cmake_prefix.cmake.in)
       endif()
@@ -136,6 +137,18 @@ macro(ament_vendor TARGET_NAME)
       ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package.bat.in)
       ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package.dsv.in)
       ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package.sh.in)
+      ament_environment_hooks(${ament_cmake_vendor_package_DIR}/templates/vendor_package.ps1.in)
+
+      # Generate and install local_setup.ps1 for PowerShell support on Windows
+      configure_file(
+        "${ament_cmake_vendor_package_DIR}/templates/local_setup.ps1.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_vendor_package/local_setup.ps1"
+        @ONLY
+      )
+      install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_vendor_package/local_setup.ps1"
+        DESTINATION "share/${PROJECT_NAME}"
+      )
 
       # Resource index marker
       ament_index_register_resource("vendor_packages" CONTENT "opt/${PROJECT_NAME}")

--- a/ament_cmake_vendor_package/cmake/templates/local_setup.ps1.in
+++ b/ament_cmake_vendor_package/cmake/templates/local_setup.ps1.in
@@ -1,0 +1,14 @@
+# generated from ament_cmake_vendor_package/cmake/templates/local_setup.ps1.in
+
+# the current prefix is two levels up from the package specific share folder
+$env:AMENT_CURRENT_PREFIX=(Get-Item $PSCommandPath).Directory.Parent.Parent.FullName
+
+# source all environment hooks of this package
+if (Test-Path "$env:AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/environment/vendor_package.ps1") {
+  . "$env:AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/environment/vendor_package.ps1"
+}
+if (Test-Path "$env:AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/environment/vendor_package_cmake_prefix.ps1") {
+  . "$env:AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/environment/vendor_package_cmake_prefix.ps1"
+}
+
+Remove-Item Env:\AMENT_CURRENT_PREFIX

--- a/ament_cmake_vendor_package/cmake/templates/vendor_package.ps1.in
+++ b/ament_cmake_vendor_package/cmake/templates/vendor_package.ps1.in
@@ -1,0 +1,36 @@
+# generated from ament_cmake_vendor_package/cmake/templates/vendor_package.ps1.in
+
+function ament_vendor_prepend_unique_value {
+  param (
+    $_listname,
+    $_value
+  )
+  if (Test-Path Env:$_listname) {
+    $_values=(Get-Item env:$_listname).Value
+  } else {
+    $_values=""
+  }
+  $_all_values="$_value"
+  if ($_values) {
+    $_values.Split(";") | ForEach-Object {
+      if ($_) {
+        if ($_ -ne $_value) {
+          $_all_values="${_all_values};$_"
+        }
+      }
+    }
+  }
+  Set-Item env:\$_listname -Value "$_all_values"
+}
+
+if (Test-Path "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/bin") {
+  ament_vendor_prepend_unique_value PATH "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/bin"
+}
+
+if (Test-Path "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/lib") {
+  ament_vendor_prepend_unique_value @_LIBDIR_VAR_NAME@ "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/lib"
+}
+
+if (Test-Path "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/lib64") {
+  ament_vendor_prepend_unique_value @_LIBDIR_VAR_NAME@ "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/lib64"
+}

--- a/ament_cmake_vendor_package/cmake/templates/vendor_package_cmake_prefix.ps1.in
+++ b/ament_cmake_vendor_package/cmake/templates/vendor_package_cmake_prefix.ps1.in
@@ -1,0 +1,28 @@
+# generated from ament_cmake_vendor_package/cmake/templates/vendor_package_cmake_prefix.ps1.in
+
+function ament_vendor_prepend_unique_value {
+  param (
+    $_listname,
+    $_value
+  )
+  if (Test-Path Env:$_listname) {
+    $_values=(Get-Item env:$_listname).Value
+  } else {
+    $_values=""
+  }
+  $_all_values="$_value"
+  if ($_values) {
+    $_values.Split(";") | ForEach-Object {
+      if ($_) {
+        if ($_ -ne $_value) {
+          $_all_values="${_all_values};$_"
+        }
+      }
+    }
+  }
+  Set-Item env:\$_listname -Value "$_all_values"
+}
+
+if (Test-Path "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@") {
+  ament_vendor_prepend_unique_value CMAKE_PREFIX_PATH "$env:AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@"
+}

--- a/ament_cmake_vendor_package/test/CMakeLists.txt
+++ b/ament_cmake_vendor_package/test/CMakeLists.txt
@@ -26,6 +26,12 @@ ament_vendor(depender
   SKIP_INSTALL
 )
 
+ament_vendor(exlib_install
+  VCS_URL exlib_good
+  VCS_TYPE path
+  GLOBAL_HOOK
+)
+
 externalproject_add_stepdependencies(depender configure exlib_bad exlib_good)
 
 if(WIN32)
@@ -50,3 +56,19 @@ ament_add_test(layering_bad
   COMMAND "${depender_BINDIR}/depender" "should-fail"
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
   APPEND_LIBRARY_DIRS "${exlib_bad_LIBDIR}" "${exlib_good_LIBDIR}")
+
+if(WIN32)
+  configure_file(
+    test_powershell_setup.ps1
+    ${CMAKE_CURRENT_BINARY_DIR}/test_powershell_setup.ps1
+    COPYONLY
+  )
+
+  ament_add_test(test_powershell_setup
+    COMMAND powershell.exe -NonInteractive -ExecutionPolicy Bypass -File
+      "${CMAKE_CURRENT_BINARY_DIR}/test_powershell_setup.ps1"
+      "${CMAKE_INSTALL_PREFIX}"
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+  )
+endif()
+

--- a/ament_cmake_vendor_package/test/test_powershell_setup.ps1
+++ b/ament_cmake_vendor_package/test/test_powershell_setup.ps1
@@ -1,0 +1,31 @@
+param (
+  [string]$InstallPrefix
+)
+
+$env:PATH = ""
+$env:CMAKE_PREFIX_PATH = ""
+
+$setup_file = "$InstallPrefix/share/ament_cmake_vendor_package_test/local_setup.ps1"
+if (-not (Test-Path $setup_file)) {
+  Write-Error "Could not find local_setup.ps1 at $setup_file"
+  exit 1
+}
+
+# Source the setup file
+. $setup_file
+
+Write-Host "PATH: $env:PATH"
+Write-Host "CMAKE_PREFIX_PATH: $env:CMAKE_PREFIX_PATH"
+
+if (-not "$env:PATH".Contains("ament_cmake_vendor_package_test")) {
+  Write-Error "PATH was not updated by local_setup.ps1"
+  exit 1
+}
+
+if (-not "$env:CMAKE_PREFIX_PATH".Contains("ament_cmake_vendor_package_test")) {
+  Write-Error "CMAKE_PREFIX_PATH was not updated by local_setup.ps1"
+  exit 1
+}
+
+Write-Host "PowerShell local_setup.ps1 verified successfully!"
+exit 0


### PR DESCRIPTION
When generating hooks for vendor packages, also generate hooks for powershell (because CMD is kind of miserable).

Closes https://github.com/ament/ament_cmake/issues/611

Assisted-by: Antigravity <antigravity@google.com>
