### PR TITLE
Generate links to environment dsv files in environment hooks

### DIFF
--- a/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
@@ -86,10 +86,10 @@ function(ament_environment_hooks)
       file(GENERATE OUTPUT "${dsv_file}" CONTENT "${AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename}}\n")
       # add dsv to environment hooks so they are added to local_setup files
       list(APPEND _AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv
-	"share/${PROJECT_NAME}/environment/${hook_basename}.dsv")
+        "share/${PROJECT_NAME}/environment/${hook_basename}.dsv")
       set(_AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv
-	"${_AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv}" PARENT_SCOPE)
-      
+        "${_AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv}" PARENT_SCOPE)
+
       install(
         FILES "${dsv_file}"
         DESTINATION "share/${PROJECT_NAME}/environment"

--- a/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
+++ b/ament_cmake_core/cmake/environment_hooks/ament_environment_hooks.cmake
@@ -84,6 +84,12 @@ function(ament_environment_hooks)
       # write .dsv file containing the descriptor of the environment hook
       set(dsv_file "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_environment_hooks/${hook_basename}.dsv")
       file(GENERATE OUTPUT "${dsv_file}" CONTENT "${AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_${hook_basename}}\n")
+      # add dsv to environment hooks so they are added to local_setup files
+      list(APPEND _AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv
+	"share/${PROJECT_NAME}/environment/${hook_basename}.dsv")
+      set(_AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv
+	"${_AMENT_CMAKE_ENVIRONMENT_HOOKS_dsv}" PARENT_SCOPE)
+      
       install(
         FILES "${dsv_file}"
         DESTINATION "share/${PROJECT_NAME}/environment"


### PR DESCRIPTION
This fixes #627 

The local_setup.dsv files now correctly point to any dsv files in the /environments/ folder for a generated package.