### PR TITLE
Allow modern target_link_libraries with ament_cmake_gtest

### DIFF
--- a/ament_cmake_gtest/cmake/ament_add_gtest.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest.cmake
@@ -36,6 +36,9 @@
 # :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the gtest
 #   main libraries
 # :type SKIP_LINKING_MAIN_LIBRARIES: option
+# :param LINKING_MODE: either SCOPED or UNSCOPED to use scope keywords
+#   (PRIVATE/PUBLIC/INTERFACE) in target_link_libraries() or not, respectively
+# :type LINKING_MODE: string
 # :param SKIP_TEST: if set mark the test as being skipped
 # :type SKIP_TEST: option
 # :param ENV: list of env vars to set; listed as ``VAR=value``
@@ -52,7 +55,7 @@
 macro(ament_add_gtest target)
   cmake_parse_arguments(_ARG
     "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
-    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "LINKING_MODE;RUNNER;TIMEOUT;WORKING_DIRECTORY"
     "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
     ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
@@ -64,6 +67,9 @@ macro(ament_add_gtest target)
   set(_argn_executable ${_ARG_UNPARSED_ARGUMENTS})
   if(_ARG_SKIP_LINKING_MAIN_LIBRARIES)
     list(APPEND _argn_executable "SKIP_LINKING_MAIN_LIBRARIES")
+  endif()
+  if(DEFINED _ARG_LINKING_MODE)
+    list(APPEND _argn_executable "LINKING_MODE" "${_ARG_LINKING_MODE}")
   endif()
   ament_add_gtest_executable("${target}" ${_argn_executable})
 

--- a/ament_cmake_gtest/cmake/ament_add_gtest_executable.cmake
+++ b/ament_cmake_gtest/cmake/ament_add_gtest_executable.cmake
@@ -28,6 +28,9 @@
 # :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the gtest
 #   main libraries
 # :type SKIP_LINKING_MAIN_LIBRARIES: option
+# :param LINKING_MODE: either SCOPED or UNSCOPED to use scope keywords
+#   (PRIVATE/PUBLIC/INTERFACE) in target_link_libraries() or not, respectively
+# :type LINKING_MODE: string
 #
 # @public
 #
@@ -39,7 +42,7 @@ macro(ament_add_gtest_executable target)
 endmacro()
 
 function(_ament_add_gtest_executable target)
-  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "" "" ${ARGN})
+  cmake_parse_arguments(ARG "SKIP_LINKING_MAIN_LIBRARIES" "LINKING_MODE" "" ${ARGN})
   if(NOT ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR
       "ament_add_gtest_executable() must be invoked with at least one source file")
@@ -49,13 +52,35 @@ function(_ament_add_gtest_executable target)
   # to add this target as a dependency to the "test" target
   add_executable("${target}" ${ARG_UNPARSED_ARGUMENTS})
   target_include_directories("${target}" SYSTEM PRIVATE "${GTEST_INCLUDE_DIRS}")
-  if(NOT ARG_SKIP_LINKING_MAIN_LIBRARIES)
-    target_link_libraries("${target}" ${GTEST_MAIN_LIBRARIES})
+
+  if(NOT DEFINED ARG_LINKING_MODE)
+    # Default to the old behaviour for now
+    set(ARG_LINKING_MODE "UNSCOPED")
   endif()
-  target_link_libraries("${target}" ${GTEST_LIBRARIES})
+  if(ARG_LINKING_MODE STREQUAL "SCOPED")
+    set(scope_keyword "PRIVATE")
+  elseif(ARG_LINKING_MODE STREQUAL "UNSCOPED")
+    set(scope_keyword "")
+    message(DEPRECATION
+      "The unscoped signature for ament_add_gtest_executable() is deprecated. "
+      "Instead, pass 'LINKING_MODE SCOPED' to ament_add_gtest_executable() and "
+      "update any related target_link_libraries() calls to use scope keywords "
+      "(PRIVATE/PUBLIC/INTERFACE). This will eventually become the default."
+    )
+  else()
+    message(FATAL_ERROR
+      "Invalid LINKING_MODE '${ARG_LINKING_MODE}' for target '${target}'. "
+      "Valid options are 'SCOPED' or 'UNSCOPED'."
+    )
+  endif()
+
+  if(NOT ARG_SKIP_LINKING_MAIN_LIBRARIES)
+    target_link_libraries("${target}" ${scope_keyword} ${GTEST_MAIN_LIBRARIES})
+  endif()
+  target_link_libraries("${target}" ${scope_keyword} ${GTEST_LIBRARIES})
   if(NOT WIN32)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
-    target_link_libraries("${target}" Threads::Threads)
+    target_link_libraries("${target}" ${scope_keyword} Threads::Threads)
   endif()
 endfunction()


### PR DESCRIPTION
As described in #405, the `ament_add_gtest()` and `ament_add_gtest_executable()` macros don't support subsequent calls to `target_link_libraries()` on the produced target with scope keywords (`PRIVATE`/`PUBLIC`/`INTERFACE`). Modern standards prefer to use scope keywords, so we should allow this.

CMake requires that either _all_ or _no_ calls to `target_link_libraries()` for a given target use scope keywords ([CMP0023](https://cmake.org/cmake/help/latest/policy/CMP0023.html)), so for backwards compatibility to avoid breaking downstream packages, the old behaviour is kept as a default for now, with the ability to opt in to the new behaviour by passing in `LINKING_MODE SCOPED` to `ament_add_gtest()` and friends. Use of the old method will now emit a deprecation warning, like:

```
CMake Deprecation Warning at /root/ws/install/ament_cmake_gtest/share/ament_cmake_gtest/cmake/ament_add_gtest_executable.cmake:64 (message):
  The unscoped signature for ament_add_gtest_executable() is deprecated.
  Instead, pass 'LINKING_MODE SCOPED' to ament_add_gtest_executable() and
  update any related target_link_libraries() calls to use scope keywords
  (PRIVATE/PUBLIC/INTERFACE).  This will eventually become the default.
Call Stack (most recent call first):
  /root/ws/install/ament_cmake_gtest/share/ament_cmake_gtest/cmake/ament_add_gtest_executable.cmake:40 (_ament_add_gtest_executable)
  /root/ws/install/ament_cmake_gtest/share/ament_cmake_gtest/cmake/ament_add_gtest.cmake:74 (ament_add_gtest_executable)
  CMakeLists.txt:146 (ament_add_gtest)
```

Eventually, after giving downstream users time to migrate, we can switch the default behaviour to `SCOPED`.

See also #423.