### PR TITLE
Make ament_export_libraries respect CMAKE_INSTALL_LIBDIR

### DIFF
--- a/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
+++ b/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
@@ -37,9 +37,13 @@ if(NOT _exported_libraries STREQUAL "")
     if(NOT IS_ABSOLUTE "${_library}")
       # search for library target relative to this CMake file
       set(_lib "NOTFOUND")
+      set(_install_libdir "@CMAKE_INSTALL_LIBDIR@")
+      if(_install_libdir STREQUAL "")
+        set(_install_libdir "lib")
+      endif()
       find_library(
         _lib NAMES "${_library}"
-        PATHS "${@PROJECT_NAME@_DIR}/../../../lib"
+        PATHS "${@PROJECT_NAME@_DIR}/../../../${_install_libdir}"
         NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH
       )
 

--- a/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
+++ b/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
@@ -39,7 +39,11 @@ if(NOT _exported_libraries STREQUAL "")
       set(_lib "NOTFOUND")
       find_library(
         _lib NAMES "${_library}"
-        PATHS "${@PROJECT_NAME@_DIR}/../../../@CMAKE_INSTALL_LIBDIR@"
+        PATHS
+        # This is for packages that install libraries to destinations using GNUInstallDirs variables.
+        "${@PROJECT_NAME@_DIR}/../../../@CMAKE_INSTALL_LIBDIR@"
+        # Historically ROS packages have installed libraries to this hardcoded lib directory.
+        "${@PROJECT_NAME@_DIR}/../../../lib"
         NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH
       )
 

--- a/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
+++ b/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in
@@ -37,13 +37,9 @@ if(NOT _exported_libraries STREQUAL "")
     if(NOT IS_ABSOLUTE "${_library}")
       # search for library target relative to this CMake file
       set(_lib "NOTFOUND")
-      set(_install_libdir "@CMAKE_INSTALL_LIBDIR@")
-      if(_install_libdir STREQUAL "")
-        set(_install_libdir "lib")
-      endif()
       find_library(
         _lib NAMES "${_library}"
-        PATHS "${@PROJECT_NAME@_DIR}/../../../${_install_libdir}"
+        PATHS "${@PROJECT_NAME@_DIR}/../../../@CMAKE_INSTALL_LIBDIR@"
         NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH
       )
 

--- a/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries_package_hook.cmake
+++ b/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries_package_hook.cmake
@@ -18,6 +18,7 @@
 # as well as linker flags
 
 # generate and register extra file for libraries
+include(GNUInstallDirs)
 set(_generated_extra_file
   "${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_export_libraries/ament_cmake_export_libraries-extras.cmake")
 configure_file(


### PR DESCRIPTION
Fixes https://github.com/ament/ament_cmake/issues/630

This makes `ament_export_libraries` respect the GNUInstallDirs install locations. Most ROS packages hardcode `lib` as the install location.

https://github.com/ros2/rcutils/blob/fb40080931810249466e3b6407574807d142ad7e/CMakeLists.txt#L114

However, it's totally reasonable to install libraries to `CMAKE_INSTALL_LIBDIR` from [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#module:GNUInstallDirs).

https://github.com/BehaviorTree/BehaviorTree.CPP/blob/c09169601053c3a057fde98a269dba2cfa183cae/CMakeLists.txt#L33

This change makes the `find_library` check both locations.

I used Gemini to make this change.